### PR TITLE
Feature guides: Objective-C, Swift, PHP, Python, Ruby, Rust

### DIFF
--- a/docs/themis/languages/cpp/features.md
+++ b/docs/themis/languages/cpp/features.md
@@ -319,8 +319,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```cpp
 std::vector<uint8_t> decrypted = cell.decrypt(encrypted, context);
-if (looks_correct(decrypted)) {
-    // process decrypted data
+if (!correct(decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/cpp/features.md
+++ b/docs/themis/languages/cpp/features.md
@@ -860,7 +860,9 @@ for (;;) {
 Once the comparison is complete, you can get the results (on each side):
 
 ```cpp
-bool secrets_equal = comparison.get();
+if (comparison.get()) {
+    // shared secrets match
+}
 ```
 
 Secure Comparator performs consistency checks on the protocol messages

--- a/docs/themis/languages/cpp/features.md
+++ b/docs/themis/languages/cpp/features.md
@@ -148,13 +148,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/cpp/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -218,8 +220,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -277,8 +277,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -373,6 +371,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/cpp/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -542,6 +544,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/cpp/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -818,6 +824,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/cpp/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/go/features.md
+++ b/docs/themis/languages/go/features.md
@@ -614,6 +614,15 @@ GoThemis supports only
 (aka *wrap–unwrap* mode).
 It is easy to integrate into existing applications with established network processing path.
 
+{{< hint info >}}
+**Note:**
+We consider buffer-aware API more fit for typical Go applications,
+so currently Secure Session supports only this mode.
+However, if you find that [callback-oriented API](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+might be a good fit for your use case,
+[let us know](mailto:dev@cossacklabs.com).
+{{< /hint >}}
+
 #### Establishing connection
 
 The client initiates the connection and sends the first request to the server:

--- a/docs/themis/languages/go/features.md
+++ b/docs/themis/languages/go/features.md
@@ -142,13 +142,13 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+See [full API reference here](https://pkg.go.dev/github.com/cossacklabs/themis/gothemis/cell?tab=doc).
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -217,8 +217,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -275,8 +273,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -377,6 +373,8 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+See [full API reference here](https://pkg.go.dev/github.com/cossacklabs/themis/gothemis/message?tab=doc).
 
 ### Signature mode
 
@@ -533,6 +531,8 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+See [full API reference here](https://pkg.go.dev/github.com/cossacklabs/themis/gothemis/session?tab=doc).
 
 ### Setting up Secure Session
 
@@ -722,6 +722,8 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+See [full API reference here](https://pkg.go.dev/github.com/cossacklabs/themis/gothemis/compare?tab=doc).
 
 ### Comparing secrets
 

--- a/docs/themis/languages/java/features.md
+++ b/docs/themis/languages/java/features.md
@@ -944,7 +944,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```java
 if (comparison.getResult() == SecureCompare.CompareResult.MATCH) {
-    // shared secrets are equal
+    // shared secrets match
 }
 ```
 

--- a/docs/themis/languages/java/features.md
+++ b/docs/themis/languages/java/features.md
@@ -316,8 +316,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```java
 byte[] decrypted = cell.decrypt(encrypted, context);
-if (looksCorrect(decrypted)) {
-    // process decrypted data
+if (!correct(decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/java/features.md
+++ b/docs/themis/languages/java/features.md
@@ -143,13 +143,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/java/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -214,8 +216,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -276,8 +276,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -370,6 +368,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/java/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -547,6 +549,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/java/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -895,6 +901,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/java/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/kotlin/features.md
+++ b/docs/themis/languages/kotlin/features.md
@@ -923,7 +923,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```kotlin
 if (comparison.result == SecureCompare.CompareResult.MATCH) {
-    // shared secrets are equal
+    // shared secrets match
 }
 ```
 

--- a/docs/themis/languages/kotlin/features.md
+++ b/docs/themis/languages/kotlin/features.md
@@ -309,8 +309,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```kotlin
 ByteArray decrypted = cell.decrypt(encrypted, context)
-if (looksCorrect(decrypted)) {
-    // process decrypted data
+if (!correct(decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/kotlin/features.md
+++ b/docs/themis/languages/kotlin/features.md
@@ -140,13 +140,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/kotlin/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -211,8 +213,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -269,8 +269,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -363,6 +361,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/kotlin/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -534,6 +536,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/kotlin/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -874,6 +880,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/kotlin/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/nodejs/features.md
+++ b/docs/themis/languages/nodejs/features.md
@@ -303,8 +303,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```javascript
 let decrypted = cell.decrypt(encrypted, context)
-if (looksCorrect(decrypted)) {
-    // process decrypted data
+if (!correct(decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/nodejs/features.md
+++ b/docs/themis/languages/nodejs/features.md
@@ -706,7 +706,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```javascript
 if (comparison.isMatch()) {
-    // secret equal
+    // shared secrets match
 }
 ```
 

--- a/docs/themis/languages/nodejs/features.md
+++ b/docs/themis/languages/nodejs/features.md
@@ -139,13 +139,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/nodejs/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -207,8 +209,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -264,8 +264,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -357,6 +355,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/nodejs/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -505,6 +507,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/nodejs/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -663,6 +669,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/nodejs/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/nodejs/features.md
+++ b/docs/themis/languages/nodejs/features.md
@@ -500,14 +500,6 @@ Communication over Secure Session consists of two stages:
   - **Actual data exchange**,
     when the peers securely exchange data provided by higher-layer application protocols.
 
-Secure Session supports two operation modes:
-
-  - [**Buffer-aware API**](#buffer-aware-api)
-    in which encrypted messages are handled explicitly, with data buffers you provide.
-  - [**Callback-oriented API**](#callback-oriented-api)
-    in which Secure Session handles buffer allocation implicitly
-    and uses callbacks to notify about incoming messages or request sending outgoing messages.
-
 Read more about
 [Secure Session cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-session/)
 to understand better the underlying considerations,

--- a/docs/themis/languages/nodejs/features.md
+++ b/docs/themis/languages/nodejs/features.md
@@ -566,6 +566,15 @@ JsThemis supports only
 (aka *wrap–unwrap* mode).
 It is easy to integrate into existing applications with established network processing path.
 
+{{< hint info >}}
+**Note:**
+We consider buffer-aware API more fit for typical JavaScript applications,
+so currently Secure Session supports only this mode.
+However, if you find that [callback-oriented API](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+might be a good fit for your use case,
+[let us know](mailto:dev@cossacklabs.com).
+{{< /hint >}}
+
 #### Establishing connection
 
 The client initiates the connection and sends the first request to the server:

--- a/docs/themis/languages/objc/features.md
+++ b/docs/themis/languages/objc/features.md
@@ -863,7 +863,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```objc
 if ([comparison status] == TSComparatorMatch) {
-    // secrets match
+    // shared secrets match
 }
 ```
 

--- a/docs/themis/languages/objc/features.md
+++ b/docs/themis/languages/objc/features.md
@@ -631,6 +631,14 @@ ObjCThemis supports only
 (aka *wrap–unwrap* mode).
 It is easy to integrate into existing applications with established network processing path.
 
+{{< hint info >}}
+**Note:**
+Support for [callback-oriented API](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+in ObjCThemis is currently in development.
+If you find that it might be a good fit for your use case,
+please [let us know](mailto:dev@cossacklabs.com).
+{{< /hint >}}
+
 #### Establishing connection
 
 The client initiates the connection and sends the first request to the server:

--- a/docs/themis/languages/objc/features.md
+++ b/docs/themis/languages/objc/features.md
@@ -134,13 +134,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/objc/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -200,8 +202,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -257,8 +257,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -349,6 +347,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/objc/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -517,6 +519,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/objc/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -815,6 +821,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/objc/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/objc/features.md
+++ b/docs/themis/languages/objc/features.md
@@ -5,568 +5,861 @@ title:  Features
 
 # Features of ObjCThemis
 
-<a id="importing-themis"></a>
+After you have [installed ObjCThemis](../installation/),
+it is ready to use in your application!
+
 ## Using Themis
 
-In order to use Themis, you need to import it first.
-
-The header file is a bit different with each dependency manager. For **CocoaPods** use the following header:
+In order to use ObjCThemis, you need to import its headers:
 
 ```objc
 #import <objcthemis/objcthemis.h>
 ```
 
-If you install Themis via **Carthage**, please use this one:
+## Key generation
 
-```objc
-#import <themis/themis.h>
-```
-
-### Key generation
-
-#### Asymmetric keypair generation
+### Asymmetric keypairs
 
 Themis supports both Elliptic Curve and RSA algorithms for asymmetric cryptography.
 Algorithm type is chosen according to the generated key type.
-Asymmetric keys are necessary for [Secure Message](/pages/secure-message-cryptosystem/) and [Secure Session](/pages/secure-session-cryptosystem/) objects.
+Asymmetric keys are used by [Secure Message](#secure-message)
+and [Secure Session](#secure-session) objects.
 
-For learning purposes, you can play with [Themis Interactive Simulator](/simulator/interactive/) to get the keys and simulate the whole client-server communication.
+For learning purposes,
+you can play with [Themis Interactive Simulator](/docs/themis/debugging/themis-server/)
+to use the keys and simulate the whole client-server communication.
 
-> ⚠️ **WARNING:**
-> When you distribute private keys to your users, make sure the keys are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When using public keys of other peers, make sure they come from trusted sources
+to prevent Man-in-the-Middle attacks.
 
-> **NOTE:** When using public keys of other peers, make sure they come from trusted sources.
+When handling private keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
-To generate symmetric keys, use:
+To generate asymmetric keypairs, use:
 
 ```objc
 // Use TSKeyGenAsymmetricAlgorithmRSA to generate RSA keys instead
-TSKeyGen *keypair = [[TSKeyGen alloc] initWithAlgorithm:TSKeyGenAsymmetricAlgorithmEC];
+TSKeyGen *keypair =
+    [[TSKeyGen alloc] initWithAlgorithm:TSKeyGenAsymmetricAlgorithmEC];
 
 NSData *privateKey = keypair.privateKey;
 NSData *publicKey = keypair.publicKey;
 ```
 
-#### Symmetric key generation
+### Symmetric keys
 
 Themis uses highly efficient and secure AES algorithm for symmetric cryptography.
-A symmetric key is necessary for [Secure Cell](/pages/secure-cell-cryptosystem/) objects.
+A symmetric key is necessary for [Secure Cell](#secure-cell) objects.
 
-> **NOTE:** Symmetric key generation API will become available for objc-themis starting with Themis 0.13.0. For now, use common sense or consult [the wisdom of the Internet](https://stackoverflow.com/search?q=generate+cryptographically+secure+keys).
-
-<!--
-> ⚠️ **WARNING:**
-> When you store generated keys, make sure they are sufficiently protected.
-> See the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When handling symmetric keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
 To generate symmetric keys, use:
 
 ```objc
 NSData *masterKey = TSGenerateSymmetricKey()
 ```
--->
 
-### Secure Message
+## Secure Cell
 
-The Secure Message functions provide a sequence-independent, stateless, contextless messaging system. This may be preferred in cases that don't require frequent sequential message exchange and/or in low-bandwidth contexts. This is secure enough to exchange messages from time to time, but if you'd like to have Perfect Forward Secrecy and higher security guarantees, consider using [Secure Session](#secure-session) instead.
-
-The Secure Message functions offer two modes of operation:
-
-In **Sign/Verify** mode, the message is signed using the sender's private key and is verified by the receiver using the sender's public key. The message is packed in a suitable container and ECDSA is used by default to sign the message (when RSA key is used, RSA+PSS+PKCS#7 digital signature is used).
-
-In **Encrypt/Decrypt** mode, the message will be encrypted with a randomly generated key (in RSA) or a key derived by ECDH (in ECDSA), via symmetric algorithm with Secure Cell in seal mode (keys are 256 bits long).
-
-The mode is selected by using appropriate methods. The sender uses `wrap` and `unwrap` methods for encrypt/decrypt mode. A valid public key of the receiver and a private key of the sender are required in this mode. For sign/verify mode `sign` and `verify` methods should be used. They only require a private key for signing and a public key for verification respectively.
-
-Read more about the Secure Message's cryptographic internals [here](/pages/secure-message-cryptosystem/).
-
-#### Encryption
-
-To encrypt a message, use client private key and server public key, and convert them to `NSData`:
-
-```objc
-// base64 encoded keys
-NSString *serverPublicKeyString = @"VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql";
-NSString *clientPrivateKeyString = @"UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg";
-
-NSData *serverPublicKey =
-    [[NSData alloc] initWithBase64EncodedString:serverPublicKeyString
-                                        options:NSDataBase64DecodingIgnoreUnknownCharacters];
-NSData *clientPrivateKey =
-    [[NSData alloc] initWithBase64EncodedString:clientPrivateKeyString
-                                        options:NSDataBase64DecodingIgnoreUnknownCharacters];
-```
-
-Initialise encrypter:
-
-```objc
-TSMessage *encrypter = [[TSMessage alloc] initInEncryptModeWithPrivateKey:clientPrivateKey
-                                                            peerPublicKey:serverPublicKey];
-```
-
-Encrypt message:
-
-```objc
-NSString *message = @"All your base are belong to us!";
-
-NSError *themisError;
-NSData *encryptedMessage = [encrypter wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                         error:&themisError];
-if (themisError) {
-    NSLog(@"failed to encrypt: %@", themisError);
-    return;
-}
-NSLog(@"encrypted message: %@", encryptedMessage);
-```
-
-Result (the encryption result on the same data chunk is different every time and can't be used as a test):
-
-```
-encrypted message: <20270426 53000000 00010140 0c000000 10000000 1f000000 ad443c21 d6d7df98 a101e48b b3757b04 c5710e04 5720b3c2 fe674f54 73e10ad4 ee722d3e 42244b6d c5099ac4 89dfda90 75fae62a aa733872 c8180d>
-```
-
-#### Decryption
-
-Use server private key and client public key for decryption:
-
-```objc
-// base64 encoded keys
-NSString *serverPrivateKeyString = @"UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR";
-NSString *clientPublicKeyString = @"VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d";
-
-NSData *serverPrivateKey =
-    [[NSData alloc] initWithBase64EncodedString:serverPrivateKeyString
-                                        options:NSDataBase64DecodingIgnoreUnknownCharacters];
-NSData *clientPublicKey =
-    [[NSData alloc] initWithBase64EncodedString:clientPublicKeyString
-                                        options:NSDataBase64DecodingIgnoreUnknownCharacters];
-```
-
-Initialise decrypter:
-
-```objc
-TSMessage *decrypter = [[TSMessage alloc] initInEncryptModeWithPrivateKey:serverPrivateKey
-                                                            peerPublicKey:clientPublicKey];
-```
-
-Decrypt message:
-
-```objc
-NSError *themisError;
-NSData *decryptedMessage = [decrypter unwrapData:encryptedMessage
-                                           error:&themisError];
-if (themisError) {
-    NSLog(@"failed to decrypt: %@", themisError);
-    return;
-}
-
-NSString *resultString = [[NSString alloc] initWithData:decryptedMessage
-                                               encoding:NSUTF8StringEncoding];
-NSLog(@"decrypted message: %@", resultString);
-```
-
-Result:
-
-```
-decrypted message: All your base are belong to us!
-```
-
-#### Sign / Verify
-
-The only code difference from encrypt/decrypt mode is the initialiser methods:
-
-```objc
-TSMessage *signer = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:privateKey
-                                                            peerPublicKey:nil];
-
-TSMessage *verifier = [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:nil
-                                                              peerPublicKey:publicKey];
-```
-
-Use private key for signing message and public key from the same keypair for verifying message.
-
-
-### Secure Cell
-
-The **Secure Сell** functions provide the means of protection for arbitrary data contained in stores, i.e. database records or filesystem files. These functions provide both strong symmetric encryption and data authentication mechanisms.
+[**Secure Сell**](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+is a high-level cryptographic container
+aimed at protecting arbitrary data stored in various types of storage
+(e.g., databases, filesystem files, document archives, cloud storage, etc.)
+It provides both strong symmetric encryption and data authentication mechanism.
 
 The general approach is that given:
 
-- _input_: some source data to protect,
-- _key_: secret byte array,
-- _context_: plus an optional “context information”,
+  - _input:_ some source data to protect
+  - _secret:_ symmetric key or a password
+  - _context:_ and an optional “context information”
 
-Secure Cell functions will produce:
+Secure Cell will produce:
 
-- _cell_: the encrypted data,
-- _authentication tag_: some authentication data.
+  - _cell:_ the encrypted data
+  - _authentication token:_ some authentication data
 
-The purpose of the optional “context information” (i.e. a database row number or file name) is to establish a secure association between this context and the protected data. In short, even when the secret is known, if the context is incorrect, the decryption will fail.
+The purpose of the optional context information
+(e.g., a database row number or file name)
+is to establish a secure association between this context and the protected data.
+In short, even when the secret is known, if the context is incorrect then decryption will fail.
 
-The purpose of the authentication data is to verify that given a correct key (and context), the decrypted data is indeed the same as the original source data.
+The purpose of the authentication data is to validate
+that given a correct key or passphrase (and context),
+the decrypted data is indeed the same as the original source data,
+and the encrypted data has not been modified.
 
-The authentication data must be stored somewhere. The most convenient way is to simply append it to the encrypted data, but this is not always possible due to the storage architecture of an application. The Secure Cell functions offer different variants that address this issue.
+The authentication data must be stored somewhere.
+The most convenient way is to simply append it to the encrypted data,
+but this is not always possible due to the storage architecture of your application.
+Secure Cell offers variants that address this issue in different ways.
 
-By default, the Secure Cell uses the AES-256 encryption algorithm. The generated authentication data is 16 bytes long.
+By default, Secure Cell uses AES-256 for encryption.
+Authentication data takes additional 44 bytes when symmetric keys are used
+and 70 bytes in case the data is secured with a passphrase.
 
-Secure Cell is available in 3 modes:
+Secure Cell supports 2 kinds of secrets:
 
-- **[Seal mode](#secure-cell-seal-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Token protect mode](#secure-cell-token-protect-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Context imprint mode](#secure-cell-context-imprint-mode)**: length-preserving version of Secure Cell with no additional data stored. Should be used with care and caution.
+  - **Symmetric keys** are convenient to store and efficient to use for machines.
+    However, they are relatively long and hard for humans to remember.
 
-You can learn more about the underlying considerations, limitations, and features [here](/pages/secure-cell-cryptosystem/).
+  - **Passphrases**, in contrast, can be shorter and easier to remember.
 
-#### Initialising Secure Cell
+    However, passphrases are typically much less random than keys.
+    Secure Cell uses a [_key derivation function_][KDF] (KDF) to compensate for that
+    and achieves security comparable to keys with shorter passphrases.
+    This comes at a significant performance cost though.
 
-In order to initialise Secure Cell object, you will need to provide master key as NSData:
+    [KDF]: /docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions
+
+Secure Cell supports 3 operation modes:
+
+  - **[Seal mode](#seal-mode)** is the most secure and easy to use.
+    Your best choice most of the time.
+    This is also the only mode that supports passphrases at the moment.
+
+  - **[Token Protect mode](#token-protect-mode)** is just as secure, but a bit harder to use.
+    This is your choice if you need to keep authentication data separate.
+
+  - **[Context Imprint mode](#context-imprint-mode)** is a length-preserving version of Secure Cell
+    with no additional data stored. Should be used carefully.
+
+Read more about
+[Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+to understand better the underlying considerations, limitations, and features of each mode.
+
+### Seal mode
+
+[**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
+is the most secure and easy to use mode of Secure Cell.
+This should be your default choice unless you need specific features of the other modes.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
+
+{{< hint info >}}
+Each secret type has its pros and cons.
+Read about [Key derivation functions](/docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions) to learn more.
+{{< /hint >}}
 
 ```objc
-NSString *masterKeyString = @"SEl4eVMzd084SUVMbVlxQzBhTnVCVW1TdlRBb0p0ZnIK";
-NSData *masterKeyData =
-    [[NSData alloc] initWithBase64EncodedString:masterKeyString
-                                        options:NSDataBase64DecodingIgnoreUnknownCharacters];
+NSData *symmetricKey = TSGenerateSymmetricKey();
+TSCellSeal *cell = [[TSCellSeal alloc] initWithKey:symmetricKey];
+
+// OR
+
+TSCellSeal *cell = [[TSCellSeal alloc] initWithPassphrase:@"a password"];
 ```
 
-#### Secure Cell Seal Mode
-
-Initialise encrypter/decrypter:
+Now you can encrypt your data using the `encrypt` method:
 
 ```objc
-TSCellSeal *cellSeal = [[TSCellSeal alloc] initWithKey:masterKeyData];
+NSData *plaintext = ...;
+NSData *context = ...;
+
+NSData *encrypted = [cell encrypt:plaintext context:context];
 ```
 
-Encrypt:
+The _associated context_ argument is optional and can be omitted.
+
+Seal mode produces encrypted cells that are slightly longer than the input:
 
 ```objc
-NSString *message = @"All your base are belong to us!";
-NSString *context = @"For great justice";
+assert(encrypted.length > plaintext.length);
+```
 
-// "context" is an optional parameter and may be omitted
-NSError *themisError;
-NSData *encryptedMessage = [cellSeal wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                      context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                        error:&themisError];
-if (themisError) {
-    NSLog(@"failed to encrypt: %@", themisError);
-    return;
+You can decrypt the data back using the `decrypt` method:
+
+```objc
+NSError *error;
+NSData *decrypted = [cell decrypt:encrypted
+                          context:context
+                            error:&error];
+if (error) {
+    // handle decryption failure
 }
-NSLog(@"encrypted message: %@", encryptedMessage);
 ```
 
-Decrypt:
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will return an error if those are incorrect or if the encrypted data was corrupted.
+
+### Token Protect mode
+
+[**Token Protect mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#token-protect-mode)
+should be used if you cannot allow the length of the encrypted data to grow
+but have additional storage available elsewhere for the authentication token.
+Other than that,
+Token Protect mode has the same security properties as the Seal mode.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
 ```objc
-NSError *themisError;
-NSData *decryptedMessage = [cellSeal unwrapData:encryptedMessage
-                                        context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                          error:&themisError];
-if (themisError) {
-    NSLog(@"failed to decrypt: %@", themisError);
-    return;
+NSData *symmetricKey = TSGenerateSymmetricKey();
+
+TSCellToken *cell = [[TSCellToken alloc] initWithKey:symmetricKey];
+```
+
+Now you can encrypt the data using the `encrypt` method:
+
+```objc
+NSData *plaintext = ...;
+NSData *context = ...;
+
+TSCellTokenEncryptedResult *result = [cell encrypt:plaintext
+                                           context:context];
+NSData *encrypted = result.encrypted;
+NSData *authToken = result.token;
+```
+
+The _associated context_ argument is optional and can be omitted.
+
+Token Protect mode produces encrypted text and authentication token separately.
+Encrypted data has the same length as the input:
+
+```objc
+assert(encrypted.length == plaintext.length);
+```
+
+You need to save both the encrypted data and the token, they are necessary for decryption.
+Use the `decrypt` method for that:
+
+```objc
+NSError *error;
+NSData *decrypted = [cell decrypt:encrypted
+                            token:authToken
+                          context:context
+                            error:&error];
+if (error) {
+    // handle decryption failure
 }
-
-NSString *resultString = [[NSString alloc] initWithData:decryptedMessage
-                                               encoding:NSUTF8StringEncoding];
-NSLog(@"decrypted message: %@", resultString);
 ```
 
-#### Secure Cell Token-Protect Mode
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will return an error if those are incorrect
+or if the data or the authentication token was corrupted.
 
-Initialise encrypter/decrypter:
+### Context Imprint mode
+
+[**Context Imprint mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#context-imprint-mode)
+should be used if you absolutely cannot allow the length of the encrypted data to grow.
+This mode is a bit harder to use than the Seal and Token Protect modes.
+Context Imprint mode also provides slightly weaker integrity guarantees.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Context Imprint mode supports only [symmetric keys](#symmetric-keys).
 
 ```objc
-TSCellToken *cellToken = [[TSCellToken alloc] initWithKey:masterKeyData];
+NSData *symmetricKey = TSGenerateSymmetricKey();
+
+TSCellContextImprint *cell =
+    [[TSCellContextImprint alloc] initWithKey:symmetricKey];
 ```
 
-Encryption:
+Now you can encrypt the data using the `encrypt` method:
 
 ```objc
-NSString *message = @"Roses are grey. Violets are grey.";
-NSString *context = @"I'm a dog";
+NSData *plaintext = ...;
+NSData *context = ...;
 
-// "context" is an optional parameter and may be omitted
-NSError *themisError;
-TSCellTokenEncryptedData *encryptedMessage =
-    [cellToken wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                  error:&themisError];
+NSData *encrypted = [cell encrypt:plaintext context:context];
+```
 
-if (themisError) {
-    NSLog(@"failed to encrypt: %@", themisError);
-    return;
+{{< hint info >}}
+**Note:**
+Context Imprint mode **requires** associated context for encryption and decryption.
+For the highest level of security, use a different context for each data piece.
+{{< /hint >}}
+
+Context Imprint mode produces encrypted text of the same size as the input:
+
+```objc
+assert(encrypted.length == plaintext.length);
+```
+
+You can decrypt the data back using the `decrypt` method:
+
+```objc
+NSData *decrypted = [cell decrypt:encrypted context:context];
+if (looksCorrect(decrypted)) {
+    // process decrypted data
 }
-NSLog(@"encrypted message: %@", encryptedMessage.cipherText);
-NSLog(@"authentication token: %@", encryptedMessage.token);
 ```
 
-Decryption:
+{{< hint warning >}}
+**Warning:**
+In Context Imprint mode, Secure Cell cannot validate correctness of the decrypted data.
+If an incorrect secret or context is used, or if the data has been corrupted,
+Secure Cell will return garbage output without returning an error.
+{{< /hint >}}
+
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+You should also do some sanity checks after decryption.
+
+## Secure Message
+
+[**Secure Message**](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+is a lightweight container
+that can help deliver some message or data to your peer in a secure manner.
+It provides a sequence-independent, stateless, contextless messaging system.
+This may be preferred in cases that don't require frequent sequential message exchange
+and/or in low-bandwidth contexts.
+
+Secure Message is secure enough to exchange messages from time to time,
+but if you'd like to have [_perfect forward secrecy_](https://en.wikipedia.org/wiki/Forward_secrecy)
+and higher security guarantees,
+consider using [Secure Session](#secure-session) instead.
+
+Secure Message offers two modes of operation:
+
+  - In [**Sign–Verify mode**](#signature-mode),
+    the message is signed by the sender using their private key,
+    then it is verified by the recipient using the sender's public key.
+
+    The message is packed in a suitable container and signed with an appropriate algorithm,
+    based on the provided keypair type.
+    Note that the message is _not encrypted_ in this mode.
+
+  - In [**Encrypt–Decrypt mode**](#encryption-mode),
+    the message will be additionally encrypted
+    with an intermediate symmetric key using [Secure Cell](#secure-cell) in Seal mode.
+
+    The intermediate key is generated in such way that only the recipient can recover it.
+    The sender needs to provide their own private key
+    and the public key of the intended recipient.
+    Correspondingly, to get access to the message content,
+    the recipient will need to use their private key
+    along with the public key of the expected sender.
+
+Read more about
+[Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+to understand better the underlying considerations, limitations, and features of each mode.
+
+### Signature mode
+
+[**Signature mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#signed-messages)
+only adds cryptographic signatures over the messages,
+enough for anyone to authenticate them and prevent tampering
+but without additional confidentiality guarantees.
+
+To begin, the sender needs to generate an [asymmetric keypair](#asymmetric-keypairs).
+The private key stays with the sender and the public key should be published.
+Any recipient with the public key will be able to verify messages
+signed by the sender which owns the corresponding private key.
+
+The **sender** initialises Secure Message using their private key:
 
 ```objc
-NSError *themisError;
-NSData *decryptedMessage = [cellToken unwrapData:encryptedMessage
-                                         context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                           error:&themisError];
-if (themisError) {
-    NSLog(@"failed to decrypt: %@", themisError);
-    return;
+TSKeyGen *keypair =
+    [[TSKeyGen alloc] initWithAlgorithm:TSKeyGenAsymmetricAlgorithmEC];
+NSData *privateKey = keypair.privateKey;
+NSData *publicKey = keypair.publicKey;
+
+TSMessage *secureMessage =
+    [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:privateKey
+                                            peerPublicKey:nil];
+```
+
+Messages can be signed using the `wrapData` method:
+
+```objc
+NSData *message = ...;
+
+NSError *error;
+NSData *signedMessage = [secureMessage wrapData:message error:&error];
+```
+
+To verify messages, the **recipient** first has to obtain the sender's public key.
+Secure Message should be initialised using only the public key:
+
+```objc
+NSData *peerPublicKey = ...;
+
+TSMessage *secureMessage =
+    [[TSMessage alloc] initInSignVerifyModeWithPrivateKey:nil
+                                            peerPublicKey:peerPublicKey];
+```
+
+Now the receipent may verify messages signed by the sender using the `unwrapData` method:
+
+```objc
+NSError *error;
+NSData *verifiedMessage = [secureMessage unwrapData:signedMessage
+                                              error:&error];
+if (error) {
+    // handle verification error
 }
-
-NSString *resultString = [[NSString alloc] initWithData:decryptedMessage
-                                               encoding:NSUTF8StringEncoding];
-NSLog(@"decrypted message: %@", resultString);
 ```
 
-#### Secure Cell Context-Imprint Mode
+Secure Message will return an error if the message has been modified since the sender signed it,
+or if the message has been signed by someone else, not the expected sender.
 
-Initialise encrypter/decrypter:
+### Encryption mode
+
+[**Encryption mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#encrypted-messages)
+not only certifies the integrity and authenticity of the message,
+it also guarantees its confidentialty.
+That is, only the intended recipient is able to read the encrypted message,
+as well as to verify that it has been signed by the expected sender and arrived intact.
+
+For this mode, both the sender and the recipient—let's call them
+Alice and Bob—each need to generate an [asymmetric keypair](#symmetric-keypairs) of their own,
+and then send their public keys to the other party.
+
+{{< hint info >}}
+**Note:**
+Be sure to authenticate the public keys you receive to prevent Man-in-the-Middle attacks.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
+
+**Alice** initialises Secure Message with her private key and Bob's public key:
 
 ```objc
-TSCellContextImprint *contextImprint = [[TSCellContextImprint alloc] initWithKey:masterKeyData];
+TSKeyGen *aliceKeypair =
+    [[TSKeyGen alloc] initWithAlgorithm:TSKeyGenAsymmetricAlgorithmEC];
+NSData *alicePrivateKey = aliceKeypair.privateKey;
+NSData *bobPublicKey = ...; // received securely
+
+TSMessage *aliceSecureMessage =
+    [[TSMessage alloc] initInEncryptModeWithPrivateKey:alicePrivateKey
+                                         peerPublicKey:bobPublicKey];
 ```
 
-Encryption:
+Now Alice can encrypt messages for Bob using the `wrapData` method:
 
 ```objc
-NSString *message = @"Roses are red. My name is Dave. This poem have no sense";
-NSString *context = @"Microwave";
+NSData *message = ...;
 
-// "context" is a REQUIRED parameter for context-imprint mode
-NSError *themisError;
-NSData *encryptedMessage = [contextImprint wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                            context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                              error:&themisError];
-if (themisError) {
-    NSLog(@"failed to encrypt: %@", themisError);
-    return;
+NSError *error;
+NSData *encryptedMessage = [secureMessage wrapData:message error:&error];
+```
+
+**Bob** initialises Secure Message with his private key and Alice's public key:
+
+```objc
+TSKeyGen *bobKeypair =
+    [[TSKeyGen alloc] initWithAlgorithm:TSKeyGenAsymmetricAlgorithmEC];
+NSData *bobPrivateKey = bobKeypair.privateKey;
+NSData *alicePublicKey = ...; // received securely
+
+TSMessage *bobSecureMessage =
+    [[TSMessage alloc] initInEncryptModeWithPrivateKey:bobPrivateKey
+                                         peerPublicKey:alicePublicKey];
+```
+
+With this, Bob is able to decrypt messages received from Alice
+using the `unwrapData` method:
+
+```objc
+NSError *error;
+NSData *decryptedMessage = [bobSecureMessage unwrapData:encryptedMessage
+                                                  error:&error];
+if (error) {
+    // handle decryption error
 }
-
-NSLog(@"encrypted message: %@", encryptedMessage);
 ```
 
-Decryption:
+Bob's Secure Message will return an error
+if the message has been modified since Alice encrypted it;
+or if the message was encrypted by Carol, not by Alice;
+or if the message was actually encrypted by Alice but *for Carol* instead, not for Bob.
+
+## Secure Session
+
+[**Secure Session**](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+is a lightweight protocol for securing any kind of network communication,
+on both private and public networks, including the Internet.
+It operates on the 5th layer of the network OSI model (the session layer).
+
+Secure Session provides a stateful, sequence-dependent messaging system.
+This approach is suitable for protecting long-lived peer-to-peer message exchanges
+where the secure data exchange is tied to a specific session context.
+
+Communication over Secure Session consists of two stages:
+
+  - **Session negotiation** (key agreement),
+    during which the peers exchange their cryptographic material and authenticate each other.
+    After a successful mutual authentication,
+    each peer derives a session-shared secret and other auxiliary data
+    (session ID, sequence numbers, etc.)
+
+  - **Actual data exchange**,
+    when the peers securely exchange data provided by higher-layer application protocols.
+
+<!-- (Actually, it *does* support both, but the callback API is broken.)
+
+Secure Session supports two operation modes:
+
+  - [**Buffer-aware API**](#buffer-aware-api)
+    in which encrypted messages are handled explicitly, with data buffers you provide.
+  - [**Callback-oriented API**](#callback-oriented-api)
+    in which Secure Session handles buffer allocation implicitly
+    and uses callbacks to notify about incoming messages or request sending outgoing messages.
+ -->
+
+Read more about
+[Secure Session cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+to understand better the underlying considerations,
+get an overview of the protocol and its features,
+etc.
+
+### Setting up Secure Session
+
+Secure Session has two parties called “client” and “server” for the sake of simplicity,
+but they could be more precisely called “initiator” and “acceptor” –
+the only difference between the two is in who starts the communication.
+After the session is established, either party can send messages to their peer whenever it wishes to.
+
+{{< hint info >}}
+Take a look at code samples in the [`docs/examples/objc`](https://github.com/cossacklabs/themis/tree/master/docs/examples/objc)
+and [`docs/examples/Themis-server/Obj-C`](https://github.com/cossacklabs/themis/tree/master/docs/examples/Themis-server/Obj-C)
+directories on GitHub.
+There you can find examples of Secure Session setup and usage in all modes.
+{{< /hint >}}
+
+First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
+and exchange their public keys.
+The private keys should never be shared with anyone else.
+
+Each party should also choose a unique *peer ID* –
+arbitrary byte sequence identifying their public key.
+Read more about peer IDs in [Secure Session cryptosystem overview](/docs/themis/crypto-theory/crypto-systems/secure-session/#peer-ids-and-keys).
+The peer IDs need to be exchanged along with the public keys.
+
+To identify peers, Secure Session uses a **callback interface**.
+It calls the `publicKeyFor:error:` method to locate a public key associated with presented peer ID.
+Typically, each peer keeps some sort of a database of known public keys
+and fulfills Secure Session requests from that database.
 
 ```objc
-NSError *themisError;
-NSData *decryptedMessage = [contextImprint unwrapData:encryptedMessage
-                                              context:[context dataUsingEncoding:NSUTF8StringEncoding]
-                                                error:&themisError];
-if (themisError) {
-    NSLog(@"failed to decrypt: %@", themisError);
-    return;
-}
+@interface SessionCallbacks : TSSessionTransportInterface
+@end
 
-NSString *resultString = [[NSString alloc] initWithData:decryptedMessage
-                                               encoding:NSUTF8StringEncoding];
-NSLog(@"decrypted message: %@", resultString);
-```
+@implementation SessionCallbacks
 
-### Secure Session
-
-Secure Session is a sequence- and session- dependent, stateful messaging system. It is suitable for protecting long-lived peer-to-peer message exchanges where the secure data exchange is tied to a specific session context.
-
-Secure Session operates in two stages:
-* **session negotiation** where the keys are established and cryptographic material is exchanged to generate ephemeral keys and
-* **data exchange** where exchanging of messages can be carried out between peers.
-
-You can read a more detailed description of the process [here](/pages/secure-session-cryptosystem/).
-
-Put simply, Secure Session takes the following form:
-
-- Both clients and server construct a Secure Session object, providing:
-    - an arbitrary identifier,
-    - a private key, and
-    - a callback function that enables it to acquire the public key of the peers with which they may establish communication.
-- A client will generate a "connect request" and by whatever means it will dispatch that to the server.
-- A server will enter a negotiation phase in response to a client's "connect request".
-- Clients and servers will exchange messages until a "connection" is established.
-- Once a connection is established, clients and servers may exchange secure messages according to whatever application level protocol was chosen.
-
-#### Secure Session workflow
-
-Secure Session has two parts that are called client and server for the sake of simplicity, but they could be more precisely called initiator and acceptor - the only difference between them is in who starts the communication.
-
-Secure Session relies on the user's passing a number of callback functions to send/receive messages - and the keys are retrieved from local storage (see more in [Secure Session cryptosystem description](/pages/secure-session-cryptosystem/)).
-
-
-
-#### Initialise Secure Session
-
-Client ID can be obtained from the server or generated by the client. You can play with [Themis Interactive Simulator (Themis Server)](/simulator/interactive/) to get the keys and simulate the whole client-server communication.
-
-```objc
-
-NSString *userId = [UIDevice currentDevice].name;
-
-Transport *transport = [Transport new];
-TSSession *session = [[TSSession alloc] initWithUserId:[userId dataUsingEncoding:NSUTF8StringEncoding]
-                                            privateKey:privateKey
-                                             callbacks:transport];
-```
-
-##### Transport interface
-
-Implement transport interface to return server's public key. Transport layer simply returns server public key for requests using server ID.
-
-```objc
-NSString *const kServerKey = @"VUVDMgAAAC11WDPUAhLfH+nqSBHh+XGOJBHL/cCjbtasiLZEwpokhO5QTD6g";
-
-@implementation Transport
-
-- (NSData *)publicKeyFor:(NSData *)binaryId error:(NSError **)error {
-    NSString *stringFromData = [[NSString alloc] initWithData:binaryId
-                                                     encoding:NSUTF8StringEncoding];
-    if ([stringFromData isEqualToString:@"server"]) {
-        return [[NSData alloc] initWithBase64EncodedString:kServerKey
-                                                   options:NSDataBase64DecodingIgnoreUnknownCharacters];
+- (NSData *)publicKeyFor:(NSData *)peerID error:(NSError **)error
+{
+    // Retrieve public key for peer "id" from the trusted storage.
+    if (!found) {
+        return nil;
     }
-    return nil;
+    return publicKey;
 }
 
 @end
 ```
 
-#### Connect Secure Session
+Each peer initialises Secure Session with their ID, their private key,
+and an instance of the callback interface:
 
 ```objc
-NSError *error;
-NSData *sessionEstablishingData = [session connectRequest:&error];
-if (error) {
-    NSLog(@"failed to generate connection request: %@", error);
-    return;
-}
-// send "sessionEstablishingData" to the server
+NSData *peerID = ...;
+NSData *privateKey = ...;
+
+SessionCallbacks *callbacks = [[SessionCallbacks alloc] ...];
+
+TSSession *session = [[TSSession alloc] initWithUserId:peerID
+                                            privateKey:privateKey
+                                             callbacks:callbacks];
 ```
 
-Client should send `sessionEstablishingData`, get response and check if `isSessionEstablished` before sending payload.
+{{< hint info >}}
+**Note:**
+The same callback interface may be shared by multiple Secure Session instances,
+provided it is correctly synchronised.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+<!-- (The interface exists, but it's currently unusable.)
+
+#### Transport callbacks
+
+If you wish to use the **callback-oriented API** of Secure Session,
+you have to implement two additional methods of the callback interface:
 
 ```objc
-NSData *responseData = ... // received server response data after sending "sessionEstablishingData"
+@implementation TransportCallbacks
 
-NSError *error;
-NSData *unwrappedData = [session unwrapData:responseData error:&wrappingError];
-if (error) {
-    NSLog(@"failed to negotiate: %@", error);
-    return;
+- (void)sendData:(nullable NSData *)data error:(NSError *__autoreleasing *)error
+{
+    // Send "data" to the peer over the network.
+    // Return an error if that fails.
 }
 
-if ([session isSessionEstablished]) {
-    // session is established, break out of the loop
+- (nullable NSData *)receiveDataWithError:(NSError *__autoreleasing *)error
+{
+    // Receive a message for peer and return it.
+    // Return an error if that fails.
 }
 
-// session is NOT established yet
-// send "unwrappedData" to the server again
+- (NSData *)publicKeyFor:(NSData *)peerID error:(NSError **)error
+{
+    // Implement this required method as well.
+}
+
+@end
 ```
 
-After the loop finishes, Secure Session is established and is ready to be used.
+{{< hint warning >}}
+**Warning:**
+In send–receive mode, each Secure Session needs its own instance of transport callback interface.
+The same instance cannot be shared by multiple sessions.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
 
-#### Send and receive data
+-->
+
+### Using Secure Session
+
+ObjCThemis supports only
+[**buffer-aware API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#buffer-aware-api)
+(aka *wrap–unwrap* mode).
+It is easy to integrate into existing applications with established network processing path.
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
 
 ```objc
-NSString *message = @"message to send";
-
 NSError *error;
-NSData *wrappedData = [session wrapData:[message dataUsingEncoding:NSUTF8StringEncoding]
-                                  error:&error];
-if (error) {
-    NSLog(@"failed to encrypt: %@", error);
-    return;
-}
+NSData *negotiationMessage = [session connectRequest:&error];
 
-// send "wrappedData" using NSURLSession or any other kind of transport
-
-...
-
-NSData *receivedData = ...; // receive data from network here
-
-NSError *error;
-NSData *unwrappedMessage = [session unwrapData:receivedData error:&error];
-
-if (error) {
-    NSLog(@"failed to decrypt: %@", error);
-    return;
-}
-
-NSString * receivedMessage = [[NSString alloc] initWithData:unwrappedMessage
-                                                   encoding:NSUTF8StringEncoding];
-// process "receivedMessage"
+[self sendToPeer:negotiationMessage];
 ```
 
-That's it!
-
-See the [docs/examples/Themis-server/Obj-C](https://github.com/cossacklabs/themis/tree/master/docs/examples/Themis-server/Obj-C) project to gain a full understanding and overview of how Secure Session works.
-
-
-
-### Secure Comparator
-
-Secure Comparator is an interactive protocol for two parties that compares whether they share the same secret or not. It is built around a [Zero Knowledge Proof](https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html)-based protocol ([Socialist Millionaire's Protocol](https://en.wikipedia.org/wiki/Socialist_millionaires)), with a number of [security enhancements](https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf).
-
-Secure Comparator is transport-agnostic and only requires the user(s) to pass messages in a certain sequence. The protocol itself is ingrained into the functions and requires minimal integration efforts from the developer.
-
-#### Secure Comparator workflow
-
-Secure Comparator has two parties — called "client" and "server" — the only difference between them is in who starts the comparison.
-
-#### Secure Comparator client
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
 
 ```objc
-NSString *sharedSecret = @"shared secret";
-NSData *sharedSecretData = [sharedSecret dataUsingEncoding:NSUTF8StringEncoding];
-
-TSComparator *client = [[TSComparator alloc] initWithMessageToCompare:sharedSecretData];
-
-NSError *error;
-NSData *data = [client beginCompare:&error];
-
-while ([client status] == TSComparatorNotReady) {
-    // send data to the server, receive response, and process it
-    [self sendDataToServer:data];
-    data = [self receiveResponseFromServer];
-    data = [client proceedCompare:data error:&error];
+for (;;) {
+    NSData *request = [self receiveFromPeer];
+    NSError *error;
+    NSData *reply = [session unwrapData:request error:&error];
+    if ([session isSessionEstablished]) {
+        break;
+    }
+    [self sendToPeer:reply];
 }
 ```
 
-After the loop finishes, the comparison is over and its result can be checked by calling `status`:
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+In buffer-aware API, the messages are wrapped into Secure Session protocol and sent separately:
 
 ```objc
-if ([client status] == TSComparatorMatch) {
+NSData *message = ...;
+
+NSError *error;
+NSData *encryptedMessage = [session wrapData:message error:&error];
+
+[self sendToPeer:encryptedMessage];
+```
+
+You can wrap multiple messages before sending them out.
+Encrypted messages are independent.
+
+{{< hint info >}}
+**Note:**
+Secure Session allows occasional message loss,
+slight degree of out-of-order delivery, and some duplication.
+However, it is still a sequence-dependent protocol.
+Do your best to avoid interrupting the message stream.
+{{< /hint >}}
+
+After receiving an encrypted message, you need to unwrap it:
+
+```objc
+NSData *encryptedMessage = [self receiveFromPeer];
+
+NSError *error;
+NSData *decryptedMessage = [session unwrapData:encryptedMessage
+                                         error:&error];
+if (error) {
+    // handle corrupted messages
+}
+```
+
+Secure Session ensures message integrity and will return an error
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
+
+<!-- (The interface exists, but it's currently unusable.)
+
+### Callback-oriented API
+
+[**Callback-oriented API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+(aka *send–receive* mode)
+uses Secure Session as a framework for network communication, handling data buffers implicitly.
+It allows for simpler messaging code at an expense of more complex setup code.
+
+{{< hint info >}}
+**Note:**
+Remember to [configure transport callbacks](#transport-callbacks) for Secure Session,
+they are required to use the callback-oriented API.
+{{< /hint >}}
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
+
+```objc
+NSError *error;
+[session connect:&error];
+```
+
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
+
+```objc
+for (;;) {
+    NSError *error;
+    NSData *reply = [session unwrapAndReceive:4096 error:&error];
+    if ([session isSessionEstablished]) {
+        break;
+    }
+}
+```
+
+Note that actual networking happens implicitly, within the Secure Session object
+which calls appropriate transport callbacks to send and receive data over the network.
+
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+Send messages as if the Secure Session were a network socket,
+using the `wrapAndSend` method:
+
+```objc
+NSData *message = ...;
+
+NSError *error;
+[session wrapAndSend:message error:&error];
+```
+
+Secure Session encrypts the message, wraps it into the protocol,
+and synchronously calls the `sendData` transport callback to ship the message out.
+Networking errors are reported by throwing appropriate exceptions.
+
+The receiving side uses the `unwrapAndReceive` method to receive messages:
+
+```cpp
+NSError *error;
+NSUInteger length = 4096; // max message length
+NSData *message = [session unwrapAndReceive:length error:&error];
+if (error) {
+    // handle corrupted messages
+}
+```
+
+Secure Session synchronously calls the `receiveDataWithError` transport callback
+to wait for the next message, then unwraps and decrypts it,
+and returns already decrypted message to the application.
+
+Secure Session ensures message integrity and will return an error
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
+
+-->
+
+## Secure Comparator
+
+[**Secure Comparator**](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+is an interactive protocol for two parties that compares whether they share the same secret or not.
+It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
+([Socialist Millionaire's Protocol][SMP]),
+with a number of [security enhancements][paper].
+
+[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
+[paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
+
+Secure Comparator is transport-agnostic.
+That is, the implementation handles all intricacies of the protocol,
+but the application has to supply networking capabilities to exchange the messages.
+
+Read more about
+[Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+to understand better the underlying considerations,
+get an overview of the protocol, etc.
+
+### Comparing secrets
+
+Secure Comparator has two parties called “client” and “server” for the sake of simplicity,
+but the only difference between the two is in who initiates the comparison.
+
+Both parties start by initialising Secure Comparator with the secret they need to compare:
+
+```objc
+NSData *sharedSecret = ...;
+
+TSComparator *comparison =
+    [[TSComparator alloc] initWithMessageToCompare:sharedSecret];
+```
+
+The client initiates the protocol and sends the message to the server:
+
+```objc
+NSError *error;
+NSData *message = [comparison beginCompare:&error];
+
+[self sendToPeer:message];
+```
+
+Now, each peer waits for a message from the other one,
+passes it to Secure Comparator, and gets a response that needs to be sent back.
+The comparison is complete when the response is empty:
+
+```objc
+NSError *error;
+for (;;) {
+    NSData *message = [self receiveFromPeer];
+    NSData *response = [comparison proceedCompare:message error:&error];
+    if (error) {
+        // handle protocol error
+    }
+    if ([comparison status] != TSComparatorNotReady) {
+        // Comparison complete!
+        break;
+    }
+    [self sendToPeer:response];
+}
+```
+
+Once the comparison is complete, you can get the results (on each side):
+
+```objc
+if ([comparison status] == TSComparatorMatch) {
     // secrets match
-    NSLog(@"SecureComparator secrets match");
-} else {
-    // secrets don't match
-    NSLog(@"SecureComparator secrets don't match");
 }
 ```
 
-#### Secure Comparator server
-
-The server part can be described in any language, but let's pretend here that both client and server are using Objective-C.
-
-```objc
-NSString *sharedSecret = @"shared secret";
-NSData *sharedSecretData = [sharedSecret dataUsingEncoding:NSUTF8StringEncoding];
-
-TSComparator *server = [[TSComparator alloc] initWithMessageToCompare:sharedSecretData];
-
-NSError *error;
-while ([server status] == TSComparatorNotReady) {
-    // receive from client, process, and send reply
-    NSData *data = [self receiveFromClient];
-    data = [server proceedCompare:data error:&error];
-    [self sendDataToClient:data];
-}
-```
-
-After the loop finishes, the comparison is over and its result can be checked by calling `status`:
-
-```objc
-if ([server status] == TSComparatorMatch) {
-    // secrets match
-    NSLog(@"SecureComparator secrets match");
-} else {
-    // secrets don't match
-    NSLog(@"SecureComparator secrets do not match");
-}
-```
+Secure Comparator performs consistency checks on the protocol messages
+and will return an error if they were corrupted.
+But if the other party fails to demonstrate that it has a matching secret,
+Secure Comparator will only return a negative result.

--- a/docs/themis/languages/objc/features.md
+++ b/docs/themis/languages/objc/features.md
@@ -295,8 +295,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```objc
 NSData *decrypted = [cell decrypt:encrypted context:context];
-if (looksCorrect(decrypted)) {
-    // process decrypted data
+if (!correct(decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/php/features.md
+++ b/docs/themis/languages/php/features.md
@@ -519,6 +519,14 @@ PHPThemis supports only
 (aka *wrap–unwrap* mode).
 It is easy to integrate into existing applications with established network processing path.
 
+{{< hint info >}}
+**Note:**
+Support for [callback-oriented API](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+in PHPThemis is currently in development.
+If you find that it might be a good fit for your use case,
+please [let us know](mailto:dev@cossacklabs.com).
+{{< /hint >}}
+
 #### Establishing connection
 
 The client initiates the connection and sends the first request to the server:

--- a/docs/themis/languages/php/features.md
+++ b/docs/themis/languages/php/features.md
@@ -127,13 +127,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/php/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Secure Cell in Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
 
@@ -192,8 +194,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Secure Cell in Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
 Here is how you encrypt data:
@@ -245,8 +245,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Secure Cell in Context Imprint mode supports only [symmetric keys](#symmetric-keys).
 
@@ -335,6 +333,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/php/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -460,6 +462,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/php/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 

--- a/docs/themis/languages/php/features.md
+++ b/docs/themis/languages/php/features.md
@@ -281,8 +281,8 @@ You can decrypt the data back like this:
 $decrypted = phpthemis_scell_context_imprint_decrypt($symmetric_key,
                                                      $encrypted,
                                                      $context);
-if (looks_correct($decrypted)) {
-    // process data
+if (!correct($decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/python/features.md
+++ b/docs/themis/languages/python/features.md
@@ -310,8 +310,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```python
 decrypted = cell.decrypt(encrypted, context)
-if looks_correct(decrypted):
-    # process decrypted data
+if not correct(decrypted):
+    # handle decryption failure
 ```
 
 {{< hint warning >}}

--- a/docs/themis/languages/python/features.md
+++ b/docs/themis/languages/python/features.md
@@ -793,7 +793,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```python
 if comparison.is_equal():
-    # shared secret is the same
+    # shared secrets match
 ```
 
 Secure Comparator performs consistency checks on the protocol messages

--- a/docs/themis/languages/python/features.md
+++ b/docs/themis/languages/python/features.md
@@ -3,42 +3,46 @@ weight: 4
 title:  Features
 ---
 
-# Features of JsThemis
+# Features of PyThemis
 
-<a id="importing-themis"></a>
+After you have [installed PyThemis](../installation/),
+it is ready to use in your application!
+
 ## Using Themis
 
-In order to use Themis, you need to import it first.
-
-Add to your code:
+In order to use PyThemis, you need to import it like this:
 
 ```python
 import pythemis
 ```
 
-Now you're good to go!
-
-You can also import only a certain module (keypair generation, for example):
+or just particular modules:
 
 ```python
-from pythemis import skeygen
+from pythemis import skeygen, scell, smessage, ssession, scomparator
 ```
 
-### Key generation
+## Key generation
 
-#### Asymmetric keypair generation
+### Asymmetric keypairs
 
 Themis supports both Elliptic Curve and RSA algorithms for asymmetric cryptography.
 Algorithm type is chosen according to the generated key type.
-Asymmetric keys are necessary for [Secure Message](/pages/secure-message-cryptosystem/) and [Secure Session](/pages/secure-session-cryptosystem/) objects.
+Asymmetric keys are used by [Secure Message](#secure-message)
+and [Secure Session](#secure-session) objects.
 
-For learning purposes, you can play with [Themis Interactive Simulator](/simulator/interactive/) to get the keys and simulate the whole client-server communication.
+For learning purposes,
+you can play with [Themis Interactive Simulator](/docs/themis/debugging/themis-server/)
+to use the keys and simulate the whole client-server communication.
 
-> ⚠️ **WARNING:**
-> When you distribute private keys to your users, make sure the keys are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When using public keys of other peers, make sure they come from trusted sources
+to prevent Man-in-the-Middle attacks.
 
-> **NOTE:** When using public keys of other peers, make sure they come from trusted sources.
+When handling private keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
 To generate asymmetric keypairs, use:
 
@@ -48,645 +52,751 @@ from pythemis.skeygen import GenerateKeyPair, KEY_PAIR_TYPE
 # Use KEY_PAIR_TYPE.RSA to generate RSA keys instead
 keypair = GenerateKeyPair(KEY_PAIR_TYPE.EC)
 
-# Keys are "bytes" in Python 3 and "str" in Python 2
+# Keys are retured as "bytes"
 private_key = keypair.export_private_key()
 public_key = keypair.export_public_key()
 ```
 
-#### Symmetric key generation
+### Symmetric keys
+
 Themis uses highly efficient and secure AES algorithm for symmetric cryptography.
-A symmetric key is necessary for [Secure Cell](/pages/secure-cell-cryptosystem/) objects.
+A symmetric key is necessary for [Secure Cell](#secure-cell) objects.
 
-> **NOTE:** Symmetric key generation API will become available for pythemis starting with starting with 0.13.0. For now, use common sense or consult [the wisdom of the Internet](https://stackoverflow.com/search?q=generate+cryptographically+secure+keys).
-
-
-<!--
-> ⚠️ **WARNING:**
-> When you store generated keys, make sure they are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When handling symmetric keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
 To generate symmetric keys, use:
 
 ```python
 from pythemis.skeygen import GenerateSymmetricKey
 
-# Keys are "bytes" in Python 3 and "str" in Python 2
+# Keys are retured as "bytes"
 master_key = GenerateSymmetricKey()
 ```
--->
 
-### Secure Message
+## Secure Cell
 
-The Secure Message functions provide a sequence-independent, stateless, contextless messaging system. This may be preferred in cases that don't require frequent sequential message exchange and/or in low-bandwidth contexts. This is secure enough to exchange messages from time to time, but if you'd like to have Perfect Forward Secrecy and higher security guarantees, consider using [Secure Session](#secure-session) instead.
-
-The Secure Message functions offer two modes of operation:
-
-In **Sign/Verify** mode, the message is signed using the sender's private key and is verified by the receiver using the sender's public key. The message is packed in a suitable container and ECDSA is used by default to sign the message (when RSA key is used, RSA+PSS+PKCS#7 digital signature is used).
-
-In **Encrypt/Decrypt** mode, the message will be encrypted with a randomly generated key (in RSA) or a key derived by ECDH (in ECDSA), via symmetric algorithm with Secure Cell in seal mode (keys are 256 bits long).
-
-The mode is selected by using appropriate methods. For encrypt/decrypt mode use `wrap` and `unwrap` methods of `SMessage` class. A valid public key of the receiver and a private key of the sender are required in this mode. For sign/verify mode `ssign` and `sverify` functions should be used. They only require a private key for signing and a public key for verification respectively.
-
-Read more about the Secure Message's cryptographic internals [here](/pages/secure-message-cryptosystem/).
-
-#### Secure Message interface
-
-```python
-class SMessage(object):
-   def __init__(self, private_key: bytes, peer_public_key: bytes)
-   def wrap(self, message) -> bytes
-   def unwrap(self, message) -> bytes
-
-def ssign(private_key: bytes, message: bytes) -> bytes
-def sverify(public_key: bytes, message: bytes) -> bytes
-```
-
-_Description_:
-
-`class SMessage` provides Secure Message encryption:
-
-  - `__init__(self, private_key: bytes, peer_public_key: bytes)`<br/>
-    Initialise Secure Message object with **private_key** and **peer_public_key**.<br/>
-    Throws **ThemisError** on failure.
-
-  - `wrap(self, message: bytes) -> bytes`<br/>
-    Encrypt **message**.<br/>
-    Returns encrypted Secure Message container as a binary string.<br/>
-    Throws **ThemisError** on failure.
-
-  - `unwrap(self, message: bytes) -> bytes`<br/>
-    Decrypt encrypted **message**.<br/>
-    Returns decrypted message as a binary string.<br/>
-    Throws **ThemisError** on failure.
-
-Secure Message signing is provided by standalone functions:
-
-  - `ssign(private_key: bytes, message: bytes) -> bytes`<br/>
-    Sign **message** with **private_key**.<br/>
-    Returns signed Secure Message container as a binary string.<br/>
-    Throws **ThemisError** on failure.
-
-  - `sverify(public_key: bytes, message: bytes) -> bytes`<br/>
-    Verify signed **message** with **public_key**.<br/>
-    Returns original message without signature as a binary string.<br/>
-    Throws **ThemisError** on failure.
-
-> **NOTE**: For verifying the message, use public key from the same keypair as private key used for signing.
-
-
-#### Example
-
-Initialise encrypter:
-
-```python
-from pythemis.skeygen import KEY_PAIR_TYPE, GenerateKeyPair
-from pythemis.smessage import SMessage, ssign, sverify
-from pythemis.exception import ThemisError
-
-keypair1 = GenerateKeyPair(KEY_PAIR_TYPE.EC)
-keypair2 = GenerateKeyPair(KEY_PAIR_TYPE.EC)
-
-smessage = SMessage(keypair1.export_private_key(), keypair2.export_public_key())
-```
-
-Encrypt message:
-
-```python
-try:
-    encrypted_message = smessage.wrap(b'some message')
-except ThemisError as e:
-    print(e)
-```
-
-Decrypt message:
-
-```python
-try:
-    message = smessage.unwrap(encrypted_message)
-except ThemisError as e:
-    print(e)
-```
-
-
-Sign message:
-
-```python
-try:
-    signed_message = ssign(keypair1.export_private_key(), b'some message')
-except ThemisError as e:
-    print(e)
-```
-
-> **NOTE**: _For signing/verifying make sure that you use keys from the same keypair: private key for signing the message and public key for verifying it._
-
-Verify message:
-
-```python
-try:
-    message = sverify(keypair1.export_public_key(), signed_message)
-except ThemisError as e:
-    print(e)
-```
-
-### Secure Cell
-
-The **Secure Сell** functions provide the means of protection for arbitrary data contained in stores, i.e. database records or filesystem files. These functions provide both strong symmetric encryption and data authentication mechanisms.
+[**Secure Сell**](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+is a high-level cryptographic container
+aimed at protecting arbitrary data stored in various types of storage
+(e.g., databases, filesystem files, document archives, cloud storage, etc.)
+It provides both strong symmetric encryption and data authentication mechanism.
 
 The general approach is that given:
 
-- _input_: some source data to protect,
-- _key_: secret byte array,
-- _context_: plus an optional “context information”,
+  - _input:_ some source data to protect
+  - _secret:_ symmetric key or a password
+  - _context:_ and an optional “context information”
 
-Secure Cell functions will produce:
+Secure Cell will produce:
 
-- _cell_: the encrypted data,
-- _authentication tag_: some authentication data.
+  - _cell:_ the encrypted data
+  - _authentication token:_ some authentication data
 
-The purpose of the optional “context information” (i.e. a database row number or file name) is to establish a secure association between this context and the protected data. In short, even when the secret is known, if the context is incorrect, the decryption will fail.
+The purpose of the optional context information
+(e.g., a database row number or file name)
+is to establish a secure association between this context and the protected data.
+In short, even when the secret is known, if the context is incorrect then decryption will fail.
 
-The purpose of the authentication data is to verify that given a correct key (and context), the decrypted data is indeed the same as the original source data.
+The purpose of the authentication data is to validate
+that given a correct key or passphrase (and context),
+the decrypted data is indeed the same as the original source data,
+and the encrypted data has not been modified.
 
-The authentication data must be stored somewhere. The most convenient way is to simply append it to the encrypted data, but this is not always possible due to the storage architecture of an application. The Secure Cell functions offer different variants that address this issue.
+The authentication data must be stored somewhere.
+The most convenient way is to simply append it to the encrypted data,
+but this is not always possible due to the storage architecture of your application.
+Secure Cell offers variants that address this issue in different ways.
 
-By default, the Secure Cell uses the AES-256 encryption algorithm. The generated authentication data is 16 bytes long.
+By default, Secure Cell uses AES-256 for encryption.
+Authentication data takes additional 44 bytes when symmetric keys are used
+and 70 bytes in case the data is secured with a passphrase.
 
-Secure Cell is available in 3 modes:
+Secure Cell supports 2 kinds of secrets:
 
-- **[Seal mode](#secure-cell-seal-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Token protect mode](#secure-cell-token-protect-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Context imprint mode](#secure-cell-context-imprint-mode)**: length-preserving version of Secure Cell with no additional data stored. Should be used with care and caution.
+  - **Symmetric keys** are convenient to store and efficient to use for machines.
+    However, they are relatively long and hard for humans to remember.
 
-You can learn more about the underlying considerations, limitations, and features [here](/pages/secure-cell-cryptosystem/).
+  - **Passphrases**, in contrast, can be shorter and easier to remember.
 
-#### Secure Cell Seal mode interface
+    However, passphrases are typically much less random than keys.
+    Secure Cell uses a [_key derivation function_][KDF] (KDF) to compensate for that
+    and achieves security comparable to keys with shorter passphrases.
+    This comes at a significant performance cost though.
+
+    [KDF]: /docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions
+
+Secure Cell supports 3 operation modes:
+
+  - **[Seal mode](#seal-mode)** is the most secure and easy to use.
+    Your best choice most of the time.
+    This is also the only mode that supports passphrases at the moment.
+
+  - **[Token Protect mode](#token-protect-mode)** is just as secure, but a bit harder to use.
+    This is your choice if you need to keep authentication data separate.
+
+  - **[Context Imprint mode](#context-imprint-mode)** is a length-preserving version of Secure Cell
+    with no additional data stored. Should be used carefully.
+
+Read more about
+[Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+to understand better the underlying considerations, limitations, and features of each mode.
+
+### Seal mode
+
+[**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
+is the most secure and easy to use mode of Secure Cell.
+This should be your default choice unless you need specific features of the other modes.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
+
+{{< hint info >}}
+Each secret type has its pros and cons.
+Read about [Key derivation functions](/docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions) to learn more.
+{{< /hint >}}
 
 ```python
-class SCellSeal(object):
-   def __init__(self, key: bytes)
-   def encrypt(self, message: bytes, context=None: bytes) -> bytes
-   def decrypt(self, message: bytes, context=None: bytes) -> bytes
-```
-
-_Description_:
-
-- `__init__(self, key: bytes)`<br/>
-  Initialise Secure Cell in _seal mode_ with **key**.
-
-- `encrypt(self, message: bytes, context=None: bytes) -> bytes`<br/>
-  Encrypt **message** with an optional **context**.<br/>
-  Returns encrypted message.<br/>
-  Throws **ThemisError** on failure.
-
-- `decrypt(self, message: bytes, context=None: bytes) -> bytes`<br/>
-  Decrypt **message** with an optional **context**.<br/>
-  Returns decrypted message.<br/>
-  Throws **ThemisError** on failure.
-
-##### Example
-
-Initialise encrypter/decrypter:
-
-```python
+from pythemis.skeygen import GenerateSymmetricKey
 from pythemis.scell import SCellSeal
 
-base64Key = b'RWRxVE4zaDFnWk1EaXR5TDRKVVFKYmlNbGpvcktxY0MK'
-masterKey = base64.decodebytes(base64Key)
+symmetric_key = GenerateSymmetricKey()
+cell = SCellSeal(key=symmetric_key)
 
-scell = SCellSeal(masterKey)
+# OR
+
+cell = SCellSeal(passphrase='a password')
 ```
 
-Encrypt:
+Now you can encrypt your data using the `encrypt` method:
 
 ```python
-encrypted_message = scell.encrypt(b'message', b'context')
+plaintext = b'a message'
+context = b'code sample'
+
+encrypted = cell.encrypt(plaintext, context)
 ```
 
-Decrypt:
+The _associated context_ argument is optional and can be omitted.
+
+Seal mode produces encrypted cells that are slightly longer than the input:
 
 ```python
-message = scell.decrypt(encrypted_message, b'context')
+assert len(encrypted) > len(plaintext)
 ```
 
-#### Secure Cell Token-protect Mode
+You can decrypt the data back using the `decrypt` method:
 
 ```python
-class SCellTokenProtect(object)
-   def __init__(self, key: bytes)
-   def encrypt(self, message: bytes, context=None: bytes) -> (bytes, bytes)
-   def decrypt(self, message: bytes, additional_auth_data: bytes, context=None: bytes) -> bytes
+from pythemis.scell import SecureCellError
+
+try:
+    decrypted = cell.decrypt(encrypted, context)
+    # process decrypted data
+except ThemisError:
+    # handle decryption failure
 ```
 
-_Description_:
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will throw an exception if those are incorrect or if the encrypted data was corrupted.
 
-- `__init__(self, key)`<br/>
-  Initialise Secure Cell in _token protect mode_ with **key**.
+### Token Protect mode
 
-- `encrypt(self, message: bytes, context=None: bytes) -> (bytes, bytes)`<br/>
-  Encrypt **message** with an optional **context**.<br/>
-  Returns two binary strings containing encrypted message and token.<br/>
-  Throws **ThemisError** on failure.
+[**Token Protect mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#token-protect-mode)
+should be used if you cannot allow the length of the encrypted data to grow
+but have additional storage available elsewhere for the authentication token.
+Other than that,
+Token Protect mode has the same security properties as the Seal mode.
 
-- `decrypt(self, message: bytes, token: bytes, context=None: bytes) -> bytes`<br/>
-  Decrypt **message** with **token** and an optional **context**.<br/>
-  Returns decrypted message.<br/>
-  Throws **ThemisError** on failure.
+<!-- See API reference here. -->
 
-##### Example
-
-Initialise encrypter/decrypter:
+Initialise a Secure Cell with a secret of your choice to start using it.
+Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
 ```python
+from pythemis.skeygen import GenerateSymmetricKey
 from pythemis.scell import SCellTokenProtect
 
-base64Key = b'RWRxVE4zaDFnWk1EaXR5TDRKVVFKYmlNbGpvcktxY0MK'
-masterKey = base64.decodebytes(base64Key)
+symmetric_key = GenerateSymmetricKey()
 
-scell = SCellTokenProtect(masterKey)
+cell = SCellTokenProtect(key=symmetric_key)
 ```
 
-Encrypt:
+Now you can encrypt the data using the `encrypt` method:
 
 ```python
-encrypted_message, additional_auth_data = scell.encrypt(b'message', b'some context')
+plaintext = b'a message'
+context = b'code sample'
+
+encrypted, token = cell.encrypt(plaintext, context)
 ```
 
-Decrypt:
+The _associated context_ argument is optional and can be omitted.
+
+Token Protect mode produces encrypted text and authentication token separately.
+Encrypted data has the same length as the input:
 
 ```python
-message = scell.decrypt(encrypted_message, additional_auth_data, b'some context')
+assert len(encrypted) == len(plaintext)
 ```
 
-#### Secure Cell Context-Imprint Mode
+You need to save both the encrypted data and the token, they are necessary for decryption.
+Use the `decrypt` method for that:
 
 ```python
-class SCellContextImprint(object):
-   def __init__(self, key: bytes)
-   def encrypt(self, message: bytes, context: bytes) -> bytes
-   def decrypt(self, message: bytes, context: bytes) -> bytes
+from pythemis.scell import SecureCellError
+
+try:
+    decrypted = cell.decrypt(encrypted, token, context)
+    # process decrypted data
+except SecureCellError:
+    # handle decryption failure
 ```
 
-_Description_:
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will throw an exception if those are incorrect
+or if the data or the authentication token was corrupted.
 
-- `__init__(self, key: bytes)`<br/>
-  Initialise Secure Cell in _context-imprint mode_ with **key**.
+### Context Imprint mode
 
-- `encrypt(self, message: bytes, context: bytes) -> bytes`<br/>
-  Encrypt **message** with **context**.<br/>
-  Returns encrypted message.<br/>
-  Throws **ThemisError** on failure.
+[**Context Imprint mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#context-imprint-mode)
+should be used if you absolutely cannot allow the length of the encrypted data to grow.
+This mode is a bit harder to use than the Seal and Token Protect modes.
+Context Imprint mode also provides slightly weaker integrity guarantees.
 
-- `decrypt(self, message: bytes, context: bytes) -> bytes`<br/>
-  Decrypt **message** with **context**.<br/>
-  Returns decrypted message.<br/>
-  Throws **ThemisError** on failure.
+<!-- See API reference here. -->
 
-> **NOTE**: Context is _required_ in context-imprint mode.
-
-##### Example
-
-Initialise encrypter/decrypter:
+Initialise a Secure Cell with a secret of your choice to start using it.
+Context Imprint mode supports only [symmetric keys](#symmetric-keys).
 
 ```python
+from pythemis.skeygen import GenerateSymmetricKey
 from pythemis.scell import SCellContextImprint
 
-base64Key = b'RWRxVE4zaDFnWk1EaXR5TDRKVVFKYmlNbGpvcktxY0MK'
-masterKey = base64.decodebytes(base64Key)
+symmetric_key = GenerateSymmetricKey()
 
-scell = SCellContextImprint(masterKey)
+cell = SCellContextImprint(key=symmetric_key)
 ```
 
-Encrypt:
+Now you can encrypt the data using the `encrypt` method:
 
 ```python
-encrypted_message = scell.encrypt(b'test message', b'test context')
+plaintext = b'a message'
+context = b'code sample'
+
+encrypted = cell.encrypt(plaintext, context)
 ```
 
-Decrypt:
+{{< hint info >}}
+**Note:**
+Context Imprint mode **requires** associated context for encryption and decryption.
+For the highest level of security, use a different context for each data piece.
+{{< /hint >}}
+
+Context Imprint mode produces encrypted text of the same length as the input:
 
 ```python
-message = scell.decrypt(encrypted_message, b'test context')
+assert len(encrypted) == len(plaintext)
 ```
 
-### Secure Session
-
-Secure Session is a sequence- and session- dependent, stateful messaging system. It is suitable for protecting long-lived peer-to-peer message exchanges where the secure data exchange is tied to a specific session context.
-
-Secure Session operates in two stages:
-
-- **session negotiation** where the keys are established and cryptographic material is exchanged to generate ephemeral keys, and
-- **data exchange** where exchanging of messages can be carried out between peers.
-
-You can read a more detailed description of the process [here](/pages/secure-session-cryptosystem/).
-
-Put simply, Secure Session takes the following form:
-
-- Both clients and server construct a Secure Session object, providing:
-    - an arbitrary identifier,
-    - a private key, and
-    - a callback function that enables it to acquire the public key of the peers with which they may establish communication.
-- A client will generate a "connect request" and by whatever means it will dispatch that to the server.
-- A server will enter a negotiation phase in response to a client's "connect request".
-- Clients and servers will exchange messages until a "connection" is established.
-- Once a connection is established, clients and servers may exchange secure messages according to whatever application level protocol was chosen.
-
-#### Secure Session interface:
+You can decrypt the data back using the `decrypt` method:
 
 ```python
-class SSession(object):
-   def __init__(self, id: bytes, private_key: bytes, transport: TransportStruct)
-   def is_established(self) -> bool
-   def connect_request(self) -> bytes
-   def wrap(self, message: bytes) -> bytes
-   def unwrap(self, message: bytes) -> bytes
-   def connect(self)
-   def send(self, message: bytes) -> int
-   def receive(self) -> bytes
+decrypted = cell.decrypt(encrypted, context)
+if looks_correct(decrypted):
+    # process decrypted data
 ```
 
-_Description_:
+{{< hint warning >}}
+**Warning:**
+In Context Imprint mode, Secure Cell cannot validate correctness of the decrypted data.
+If an incorrect secret or context is used, or if the data has been corrupted,
+Secure Cell will return garbage output without throwing an exception.
+{{< /hint >}}
 
-- `__init__(self, id: bytes, private_key: bytes, transport: TransportStruct)`<br/>
-  Initialie Secure Session object with **id**, **private_key** and **transport**.<br/>
-  Throws **ThemisError** on failure.
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+You should also do some sanity checks after decryption.
 
-- `is_established(self) -> bool`<br/>
-  Check whether Secure Session connection has been established.<br/>
-  Throws **ThemisError** on failure.
+## Secure Message
 
-- `connect(self)`<br/>
-  Create and send a Secure Session initialisation message to peer.<br/>
-  Returns nothing.<br/>
-  Throws **ThemisError** on failure.
+[**Secure Message**](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+is a lightweight container
+that can help deliver some message or data to your peer in a secure manner.
+It provides a sequence-independent, stateless, contextless messaging system.
+This may be preferred in cases that don't require frequent sequential message exchange
+and/or in low-bandwidth contexts.
 
-- `send(self, message: bytes) -> int`<br/>
-  Encrypt **message** and send it to peer.<br/>
-  Returns internal status code.<br/>
-  Throws **ThemisError** on failure.
+Secure Message is secure enough to exchange messages from time to time,
+but if you'd like to have [_perfect forward secrecy_](https://en.wikipedia.org/wiki/Forward_secrecy)
+and higher security guarantees,
+consider using [Secure Session](#secure-session) instead.
 
-- `receive(self) -> bytes`<br/>
-  Receive a message from peer, decrypt and return it.<br/>
-  Throws **ThemisError** on failure.
+Secure Message offers two modes of operation:
 
-- `connect_request(self) -> bytes`<br/>
-  Return a Secure Session initialisation message.<br/>
-  Throws **ThemisError** on failure.
+  - In [**Sign–Verify mode**](#signature-mode),
+    the message is signed by the sender using their private key,
+    then it is verified by the recipient using the sender's public key.
 
-- `wrap(self, message: bytes) -> bytes`<br/>
-  Encrypt **message** for peer.<br/>
-  Throws **ThemisError** on failure.
+    The message is packed in a suitable container and signed with an appropriate algorithm,
+    based on the provided keypair type.
+    Note that the message is _not encrypted_ in this mode.
 
-- `unwrap(self, message: bytes) -> bytes`<br/>
-  Decrypt **message** from peer.<br/>
-  Returned result may contain either decrypted data or a control message. If `is_control` property is true, the message must be sent to peer as is.<br/>
-  Throws **ThemisError** on failure.
+  - In [**Encrypt–Decrypt mode**](#encryption-mode),
+    the message will be additionally encrypted
+    with an intermediate symmetric key using [Secure Cell](#secure-cell) in Seal mode.
 
-#### Secure Session Workflow
+    The intermediate key is generated in such way that only the recipient can recover it.
+    The sender needs to provide their own private key
+    and the public key of the intended recipient.
+    Correspondingly, to get access to the message content,
+    the recipient will need to use their private key
+    along with the public key of the expected sender.
 
-Secure Session can be used in two ways:
+Read more about
+[Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+to understand better the underlying considerations, limitations, and features of each mode.
 
- - _send/receive_ – when communication flow is fully controlled by the Secure Session object.
- - _wrap/unwrap_  – when communication is controlled by the user.
+### Signature mode
 
-Secure Session has two parties called "client" and "server" for the sake of simplicity, but they could be more precisely called "initiator" and "acceptor" — the only difference between them is in who starts the communication.
+[**Signature mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#signed-messages)
+only adds cryptographic signatures over the messages,
+enough for anyone to authenticate them and prevent tampering
+but without additional confidentiality guarantees.
 
-Secure Session relies on the user's passing a number of callback functions to send/receive messages — and the keys are retrieved from local storage (see more in [Secure Session cryptosystem description](/pages/secure-session-cryptosystem/)).
+To begin, the sender needs to generate an [asymmetric keypair](#asymmetric-keypairs).
+The private key stays with the sender and the public key should be published.
+Any recipient with the public key will be able to verify messages
+signed by the sender which owns the corresponding private key.
 
-
-#### Communication flow is fully controlled by the Secure Session object
-
-##### Transport class for send/receive
-
-Implement all methods in the callbacks class:
+The **sender** uses Secure Message with only their private key:
 
 ```python
-class CustomTransport(object):
-    def __init__(self, *args, **kwargs)
-        # init communication channel with peer
+from pythemis.skeygen import GenerateKeyPair, KEY_PAIR_TYPE
+from pythemis import smessage
 
-    def send(self, message):
-        # send message to peer
+keypair = GenerateKeyPair(KEY_PAIR_TYPE.EC)
+private_key = keypair.export_private_key()
 
-    def receive(self, buffer_length):
-        # wait and receive at most buffer_length bytes from peer
-        return accepted_message
+message = b'a message'
 
-    def get_pub_key_by_id(self, user_id):
-        # retrieve public key for peer user_id from trusted storage (file, db etc.)
+signed_message = smessage.ssign(private_key, message)
+```
+
+To verify messages, the **recipient** first has to obtain the sender's public key.
+The public key is used to verify Secure Message:
+
+```python
+from pythemis.exception import ThemisError
+
+public_key = b64decode('VUVDMgAAAC360AdaAvpf33yOGJyIJG24Eg3qGHDhpzuz29DbQb0sHiAY1Rni')
+
+try:
+    verified_message = smessage.sverify(public_key, signed_message)
+    # process verified data
+except ThemisError:
+    # handle verification failure
+```
+
+Secure Message will throw an exception if the message has been modified since the sender signed it,
+or if the message has been signed by someone else, not the expected sender.
+
+### Encryption mode
+
+[**Encryption mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#encrypted-messages)
+not only certifies the integrity and authenticity of the message,
+it also guarantees its confidentialty.
+That is, only the intended recipient is able to read the encrypted message,
+as well as to verify that it has been signed by the expected sender and arrived intact.
+
+For this mode, both the sender and the recipient—let's call them
+Alice and Bob—each need to generate an [asymmetric keypair](#symmetric-keypairs) of their own,
+and then send their public keys to the other party.
+
+{{< hint info >}}
+**Note:**
+Be sure to authenticate the public keys you receive to prevent Man-in-the-Middle attacks.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
+
+**Alice** initialises Secure Message with her private key and Bob's public key:
+
+```python
+from pythemis.skeygen import GenerateKeyPair, KEY_PAIR_TYPE
+from pythemis.smessage import SMessage
+
+alice_keypair = GenerateKeyPair(KEY_PAIR_TYPE.EC)
+alice_private_key = alice_keypair.export_private_key()
+bob_public_key = b64decode('VUVDMgAAAC3ppgNuA3zW+TjNPBnDLvKteNrmvzXV2FXmJYRhLqm6A55+eL0Q')
+
+alice_secure_message = SMessage(alice_private_key, bob_public_key)
+```
+
+Now Alice can encrypt messages for Bob using the `wrap` method:
+
+```python
+message = b'a message'
+
+encrypted_message = alice_secure_message.wrap(message)
+```
+
+**Bob** initialises Secure Message with his private key and Alice's public key:
+
+```python
+bob_keypair = GenerateKeyPair(KEY_PAIR_TYPE.EC)
+bob_private_key = alice_keypair.export_private_key()
+alice_public_key = b64decode('VUVDMgAAAC0i5Jd9AryrpVKUXMZDKuAdjKq7u/6XPLZbE3T7u46sgCu9xZWs')
+
+bob_secure_message = SMessage(bob_private_key, alice_public_key)
+```
+
+With this, Bob is able to decrypt messages received from Alice
+using the `unwrap` method:
+
+```python
+from pythemis.exception import ThemisError
+
+try:
+    decrypted_message = bob_secure_message.unwrap(encrypted_message)
+    # process decrypted data
+except ThemisError:
+    # handle decryption failure
+```
+
+Bob's Secure Message will throw an exception
+if the message has been modified since Alice encrypted it;
+or if the message was encrypted by Carol, not by Alice;
+or if the message was actually encrypted by Alice but *for Carol* instead, not for Bob.
+
+## Secure Session
+
+[**Secure Session**](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+is a lightweight protocol for securing any kind of network communication,
+on both private and public networks, including the Internet.
+It operates on the 5th layer of the network OSI model (the session layer).
+
+Secure Session provides a stateful, sequence-dependent messaging system.
+This approach is suitable for protecting long-lived peer-to-peer message exchanges
+where the secure data exchange is tied to a specific session context.
+
+Communication over Secure Session consists of two stages:
+
+  - **Session negotiation** (key agreement),
+    during which the peers exchange their cryptographic material and authenticate each other.
+    After a successful mutual authentication,
+    each peer derives a session-shared secret and other auxiliary data
+    (session ID, sequence numbers, etc.)
+
+  - **Actual data exchange**,
+    when the peers securely exchange data provided by higher-layer application protocols.
+
+Secure Session supports two operation modes:
+
+  - [**Buffer-aware API**](#buffer-aware-api)
+    in which encrypted messages are handled explicitly, with data buffers you provide.
+  - [**Callback-oriented API**](#callback-oriented-api)
+    in which Secure Session handles buffer allocation implicitly
+    and uses callbacks to notify about incoming messages or request sending outgoing messages.
+
+Read more about
+[Secure Session cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+to understand better the underlying considerations,
+get an overview of the protocol and its features,
+etc.
+
+### Setting up Secure Session
+
+Secure Session has two parties called “client” and “server” for the sake of simplicity,
+but they could be more precisely called “initiator” and “acceptor” –
+the only difference between the two is in who starts the communication.
+After the session is established, either party can send messages to their peer whenever it wishes to.
+
+{{< hint info >}}
+Take a look at code samples in the [`docs/examples/python`](https://github.com/cossacklabs/themis/tree/master/docs/examples/python) directory on GitHub.
+There you can find examples of Secure Session setup and usage.
+{{< /hint >}}
+
+First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
+and exchange their public keys.
+The private keys should never be shared with anyone else.
+
+Each party should also choose a unique *peer ID* –
+arbitrary byte sequence identifying their public key.
+Read more about peer IDs in [Secure Session cryptosystem overview](/docs/themis/crypto-theory/crypto-systems/secure-session/#peer-ids-and-keys).
+The peer IDs need to be exchanged along with the public keys.
+
+To identify peers, Secure Session uses a **callback interface**.
+It calls the `get_pub_key_by_id` method to locate a public key associated with presented peer ID.
+Typically, each peer keeps some sort of a database of known public keys
+and fulfills Secure Session requests from that database.
+
+```python
+class SessionCallbacks(object):
+    def get_pub_key_by_id(self, peer_id):
+        # Retrieve public key for "peer_id" from the trusted storage.
+        if not found:
+            return b''
         return public_key
 ```
 
-##### Secure Session client
-
-First, initialise the session:
+Each peer initialises Secure Session with their ID, their private key,
+and an instance of the callback interface:
 
 ```python
 from pythemis.ssession import SSession
-session = SSession(b'some client id', client_private_key, CustomTransport())
+
+peer_id = b'Alice'
+private_key = alice_keypair.export_private_key()
+callbacks = SessionCallbacks(...)
+
+session = SSession(peer_id, private_key, callbacks)
+```
+
+{{< hint info >}}
+**Note:**
+The same callback interface may be shared by multiple Secure Session instances,
+provided it is correctly synchronised.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+#### Transport callbacks
+
+If you wish to use the **callback-oriented API** of Secure Session,
+you have to implement two additional methods of the callback interface:
+
+```python
+class TransportCallbacks(object):
+    def send(self, message):
+        # Send message bytes to the peer over the network.
+        # Raise an exception if that fails.
+
+    def receive(self, max_length):
+        # Receive a message from the peer, at most "max_length".
+        # Raise an exception if that fails.
+        return message_bytes
+
+    def get_pub_key_by_id(self, peer_id):
+        # Retrieve public key for "peer_id" from the trusted storage.
+```
+
+{{< hint warning >}}
+**Warning:**
+In send–receive mode, each Secure Session needs its own instance of transport callback interface.
+The same instance cannot be shared by multiple sessions.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+### Buffer-aware API
+
+[**Buffer-aware API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#buffer-aware-api)
+(aka *wrap–unwrap* mode)
+is easier to integrate into existing application with established network processing path.
+Here the application handles message buffers explicitly.
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
+
+```python
+request = session.connect_request()
+
+send_to_server(request)
+```
+
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
+
+```python
+while not session.is_established():
+    request = receive_from_peer()
+    reply = session.unwrap(request)
+    if reply:
+        send_to_peer(reply)
+```
+
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+Wrap the messages into Secure Session protocol and send them:
+
+```python
+message = b'a message'
+
+encrypted_message = session.wrap(message)
+
+send_to_peer(encrypted_message)
+```
+
+You can wrap multiple messages before sending them out.
+Encrypted messages are independent.
+
+{{< hint info >}}
+**Note:**
+Secure Session allows occasional message loss,
+slight degree of out-of-order delivery, and some duplication.
+However, it is still a sequence-dependent protocol.
+Do your best to avoid interrupting the message stream.
+{{< /hint >}}
+
+After receiving an encrypted message, you need to unwrap it:
+
+```python
+from pythemis.exception import ThemisError
+
+encrypted_message = receive_from_peer()
+
+try:
+    decrypted_message = session.unwrap(encrypted_message)
+    # process a message
+except ThemisError:
+    # handle corrupted messages
+```
+
+Secure Session ensures message integrity and will throw an exception
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
+
+### Callback-oriented API
+
+[**Callback-oriented API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+(aka *send–receive* mode)
+uses Secure Session as a framework for network communication, handling data buffers implicitly.
+It allows for simpler messaging code at an expense of more complex setup code.
+
+{{< hint info >}}
+**Note:**
+Remember to [configure transport callbacks](#transport-callbacks) for Secure Session,
+they are required to use the callback-oriented API.
+{{< /hint >}}
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
+
+```python
 session.connect()
+```
+
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
+
+```python
 while not session.is_established():
     session.receive()
 ```
 
-After the loop finishes, Secure Session is established and is ready to be used.
+Note that actual networking happens implicitly, within the Secure Session object
+which calls appropriate transport callbacks to send and receive data over the network.
 
-To send a message over the established session, use:
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+Send messages as if the Secure Session were a network socket,
+using the `send` method:
 
 ```python
+message = b'a message'
+
 session.send(message)
 ```
 
-To receive a message from the session:
+Secure Session encrypts the message, wraps it into the protocol,
+and synchronously calls the `send` transport callback to ship the message out.
+Networking errors are reported by throwing appropriate exceptions.
 
-```python
-message = ssession.receive()
-```
-
-##### Secure Session server
-
-First, initialise the session:
-
-```python
-session = SSession(b'some server id', server_private_key, CustomTransport())
-# there is no need to call connect() method on the server side
-while not session.is_established():
-    session.receive()
-```
-
-Sending/receiving messages works in a manner similar to the client side after the connection is established.
-
-To encrypt and send an outgoing message to the client use:
-
-```python
-session.send(message)
-```
-
-To receive and decrypt a message from the client use:
+The receiving side uses the `receive` method to receive messages:
 
 ```python
 message = session.receive()
 ```
 
-#### Communication controlled by user
+Secure Session synchronously calls the `receive` transport callback
+to wait for the next message, then unwraps and decrypts it,
+and returns already decrypted message to the application.
 
-##### Transport class for wrap/unwrap
+Secure Session ensures message integrity and will throw an exception
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
 
-Implement only required methods in the callback class:
+## Secure Comparator
 
-```python
-from pythemis.ssession import MemoryTransport
+[**Secure Comparator**](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+is an interactive protocol for two parties that compares whether they share the same secret or not.
+It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
+([Socialist Millionaire's Protocol][SMP]),
+with a number of [security enhancements][paper].
 
+[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
+[paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 
-class CustomSimpleTransport(MemoryTransport):
-   def __init__(self, *args, **kwargs)
-       # initialize trusted public keys storage
-       super(CustomSimpleTransport, self).__init__()
+Secure Comparator is transport-agnostic.
+That is, the implementation handles all intricacies of the protocol,
+but the application has to supply networking capabilities to exchange the messages.
 
-   def get_pub_key_by_id(self, user_id):
-       # retreive public key for peer user_id from trusted storage (file, db etc.)
-       return public_key
-```
+Read more about
+[Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+to understand better the underlying considerations,
+get an overview of the protocol, etc.
 
-##### Secure Session client
+### Comparing secrets
 
-First, the initialisation:
+Secure Comparator has two parties called “client” and “server” for the sake of simplicity,
+but the only difference between the two is in who initiates the comparison.
 
-```python
-session = SSession(b'user_id2', client_private_key, CustomSimpleTransport())
-# this call is only made by the client
-encrypted_message = session.connect_request()
-
-# send connect request to the peer
-response_bytes = user_communication_send_method(encrypted_message)
-message = session.unwrap(response_bytes)
-
-# establish the session
-while not session.is_established():
-    response_bytes = user_communication_send_method(message)
-    message = session.unwrap(response_bytes)
-```
-
-After the loop finishes, Secure Session is established and is ready to be used.
-
-To encrypt the outgoing message, use:
-
-```python
-encrypted_message = session.wrap(message)
-# send encrypted_message to peer by any prefered method
-```
-
-To decrypt the received message, use:
-
-```python
-# receive encrypted_message from peer
-message = session.unwrap(encrypted_message)
-```
-
-##### Secure Session server
-
-First, initialise everything:
-
-```python
-session = SSession(b'server_id_1', server_private_key, CustomSimpleTransport())
-# there is no need to call connect() or connect_request() on the server side
-
-encrypted_message = user_communication_recieve_method()
-message = session.unwrap(encrypted_message)
-
-# NOTE: The condition is different for the server because we need to send
-# the last piece of data to the client after establishing the session.
-while message.is_control:
-    # just return the unwrapped message to the user
-    user_communication_send_method(message)
-
-    encrypted_message = user_communication_recieve_method()
-    message = session.unwrap(encrypted_message)
-```
-
-Secure Session is ready.
-
-Send/receive works in the same way as the client's example above.
-
-
-### Secure Comparator
-
-Secure Comparator is an interactive protocol for two parties that compares whether they share the same secret or not. It is built around a [Zero Knowledge Proof](https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html)-based protocol ([Socialist Millionaire's Protocol](https://en.wikipedia.org/wiki/Socialist_millionaires)), with a number of [security enhancements](https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf).
-
-Secure Comparator is transport-agnostic and only requires the user(s) to pass messages in a certain sequence. The protocol itself is ingrained into the functions and requires minimal integration efforts from the developer.
-
-#### Secure Comparator interface
-
-```python
-class SComparator:
-   def __init__(self, shared_secret: bytes)
-   def begin_compare(self) -> bytes
-   def proceed_compare(self, message: bytes) -> bytes
-   def is_compared(self) -> bool
-   def is_equal(self) -> bool
-   def result(self)
-```
-
-_Description_:
-
-- `__init__(self, shared_secret: bytes)`<br/>
-  Initialise Secure Comparator object with a **shared_secret**.<br/>
-  Throws **ThemisError** on failure.
-
-- `begin_compare(self)`<br/>
-  Start comparison and return a Secure Comparator initialisation message.<br/>
-  Throws **ThemisError** on failure.
-
-- `proceed_compare(self, message)`<br/>
-  Process **message** and create the next protocol message (when necessary).<br/>
-  Throws **ThemisError** on failure.
-
-- `is_compared(self) -> bool`<br/>
-  Return True if comparison is finished.<br/>
-  Throws **ThemisError** on failure.
-
-- `is_equal(self) -> bool`<br/>
-  Return True if comparison is finished _and_ secrets are equal, otherwise return False.<br/>
-  Throws **ThemisError** on failure.
-
-- `result(self) -> int`<br/>
-  Return the original comparison result code.<br/>
-  Throws **ThemisError** on failure.
-
-#### Secure Comparator workflow
-
-Secure Comparator has two parties — called "client" and "server" — the only difference between them is in who starts the comparison.
-
-#### Secure Comparator client
+Both parties start by initialising Secure Comparator with the secret they need to compare:
 
 ```python
 from pythemis.scomparator import SComparator
 
-
-comparator = SComparator(b'shared_secret')
-
-# this call is specific to the client
-comparison_message = comparator.begin_compare()
-
-while not comparator.is_compared():
-    user_send_function(comparison_message)
-    response = user_recieve_function()
-    comparison_message = comparator.proceed_compare(response)
+comparison = SComparator(b'shared secret')
 ```
 
-After the loop finishes, the comparison is over and its result can be checked by calling `comparator.is_equal()`.
-
-#### Secure Comparator server
+The client initiates the protocol and sends the message to the server:
 
 ```python
-from pythemis.scomparator import SComparator
+message = comparison.begin_compare()
 
-
-comparator = SComparator(b'shared_secret')
-
-while not comparator.is_compared():
-     comparison_message = user_receive_function()
-     comparison_message = comparator.proceed_compare(comparison_message)
-     user_send_function(comparison_message)
+send_to_peer(message)
 ```
 
-After the loop finishes, the comparison is over and its result can be checked by calling `comparator.is_equal()`.
+Now, each peer waits for a message from the other one,
+passes it to Secure Comparator, and gets a response that needs to be sent back.
+This should repeat until the comparison is complete:
+
+```python
+while not comparison.is_compared():
+    request = receive_from_peer()
+    reply = comparison.proceed_compare(request)
+    if reply:
+        send_to_peer(reply)
+```
+
+Once the comparison is complete, you can get the results (on each side):
+
+```python
+if comparison.is_equal():
+    # shared secret is the same
+```
+
+Secure Comparator performs consistency checks on the protocol messages
+and will throw an exception if they were corrupted.
+But if the other party fails to demonstrate that it has a matching secret,
+Secure Comparator will only return a negative result.

--- a/docs/themis/languages/python/features.md
+++ b/docs/themis/languages/python/features.md
@@ -145,13 +145,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/python/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -214,8 +216,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -270,8 +270,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -363,6 +361,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/python/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -510,6 +512,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/python/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -755,6 +761,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/python/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/ruby/features.md
+++ b/docs/themis/languages/ruby/features.md
@@ -288,8 +288,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```ruby
 decrypted = cell.decrypt(encrypted, context)
-if looks_correct(decrypted)
-    # process decrypted data
+unless correct(decrypted)
+    # handle decryption failure
 end
 ```
 

--- a/docs/themis/languages/ruby/features.md
+++ b/docs/themis/languages/ruby/features.md
@@ -673,7 +673,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```ruby
 if comparison.result == Themis::Scomparator.MATCH
-    # shared secret is the same
+    # shared secrets match
 end
 ```
 

--- a/docs/themis/languages/ruby/features.md
+++ b/docs/themis/languages/ruby/features.md
@@ -134,13 +134,13 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+See [full API reference here](https://www.rubydoc.info/gems/rbthemis/Themis/Scell).
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -199,8 +199,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -251,8 +249,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -342,6 +338,8 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+See [full API reference here](https://www.rubydoc.info/gems/rbthemis/Themis/Smessage).
 
 ### Signature mode
 
@@ -475,6 +473,8 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+See [full API reference here](https://www.rubydoc.info/gems/rbthemis/Themis/Ssession).
 
 ### Setting up Secure Session
 
@@ -637,6 +637,8 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+See [full API reference here](https://www.rubydoc.info/gems/rbthemis/Themis/Scomparator).
 
 ### Comparing secrets
 

--- a/docs/themis/languages/rust/features.md
+++ b/docs/themis/languages/rust/features.md
@@ -141,13 +141,13 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+See [full API reference here](https://docs.rs/themis/latest/themis/secure_cell/index.html).
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -213,8 +213,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -272,8 +270,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -366,6 +362,8 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+See [full API reference here](https://docs.rs/themis/latest/themis/secure_message/index.html).
 
 ### Signature mode
 
@@ -530,6 +528,8 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+See [full API reference here](https://docs.rs/themis/latest/themis/secure_session/index.html).
 
 ### Setting up Secure Session
 
@@ -805,6 +805,8 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+See [full API reference here](https://docs.rs/themis/latest/themis/secure_comparator/index.html).
 
 ### Comparing secrets
 

--- a/docs/themis/languages/rust/features.md
+++ b/docs/themis/languages/rust/features.md
@@ -5,54 +5,65 @@ title:  Features
 
 # Features of RustThemis
 
+After you have [installed RustThemis](../installation/),
+it is ready to use in your application!
+
 ## Using Themis
 
-In order to use Themis, you need to import it first.
-
-Import the necessary modules and you're good to go:
+In order to use RustThemis,
+you need to import modules for relevant cryptosystems:
 
 ```rust
-use themis::*;
+use themis::keygen;
+use themis::secure_cell;
+use themis::secure_message;
+use themis::secure_session;
+use themis::secure_comparator;
 ```
 
-### Key generation
+## Key generation
 
-#### Asymmetric keypair generation
+### Asymmetric keypairs
 
 Themis supports both Elliptic Curve and RSA algorithms for asymmetric cryptography.
 Algorithm type is chosen according to the generated key type.
-Asymmetric keys are necessary for [Secure Message](/pages/secure-message-cryptosystem/) and [Secure Session](/pages/secure-session-cryptosystem/) objects.
+Asymmetric keys are used by [Secure Message](#secure-message)
+and [Secure Session](#secure-session) objects.
 
-For learning purposes, you can play with [Themis Interactive Simulator](/simulator/interactive/) to get the keys and simulate the whole client-server communication.
+For learning purposes,
+you can play with [Themis Interactive Simulator](/docs/themis/debugging/themis-server/)
+to use the keys and simulate the whole client-server communication.
 
-> ⚠️ **WARNING:**
-> When you distribute private keys to your users, make sure the keys are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When using public keys of other peers, make sure they come from trusted sources
+to prevent Man-in-the-Middle attacks.
 
-> **NOTE:** When using public keys of other peers, make sure they come from trusted sources.
+When handling private keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
 To generate asymmetric keypairs, use:
 
 ```rust
 use themis::keygen;
 
-// Use gen_rsa_key_pair to generate RSA keys instead
+// Use gen_rsa_key_pair() to generate RSA keys instead.
 let key_pair = keygen::gen_ec_key_pair();
 
 let (private_key, public_key) = key_pair.split();
 ```
 
-#### Symmetric key generation
+### Symmetric keys
 
 Themis uses highly efficient and secure AES algorithm for symmetric cryptography.
-A symmetric key is necessary for [Secure Cell](/pages/secure-cell-cryptosystem/) objects.
+A symmetric key is necessary for [Secure Cell](#secure-cell) objects.
 
-> **NOTE:** Symmetric key generation API will become available for Rust-Themis starting with Themis 0.13.0. For now, use common sense or consult [the wisdom of the Internet](https://stackoverflow.com/search?q=generate+cryptographically+secure+keys).
-
-<!--
-> ⚠️ **WARNING:**
-> When you store generated keys, make sure they are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When handling symmetric keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
 To generate symmetric keys, use:
 
@@ -61,292 +72,786 @@ use themis::keys::SymmetricKey;
 
 let master_key = SymmetricKey::new();
 ```
--->
 
-### Secure Message
+## Secure Cell
 
-The Secure Message functions provide a sequence-independent, stateless, contextless messaging system. This may be preferred in cases that don't require frequent sequential message exchange and/or in low-bandwidth contexts. This is secure enough to exchange messages from time to time, but if you'd like to have Perfect Forward Secrecy and higher security guarantees, consider using [Secure Session](#secure-session) instead.
-
-The Secure Message functions offer two modes of operation:
-
-In **Sign/Verify** mode, the message is signed using the sender's private key and is verified by the receiver using the sender's public key. The message is packed in a suitable container and ECDSA is used by default to sign the message (when RSA key is used, RSA+PSS+PKCS#7 digital signature is used).
-
-In **Encrypt/Decrypt** mode, the message will be encrypted with a randomly generated key (in RSA) or a key derived by ECDH (in ECDSA), via symmetric algorithm with Secure Cell in seal mode (keys are 256 bits long).
-
-The mode is selected by using appropriate methods. The sender uses `wrap` and `unwrap` methods for encrypt/decrypt mode. A valid public key of the receiver and a private key of the sender are required in this mode. For sign/verify mode `sign` and `verify` methods should be used. They only require a private key for signing and a public key for verification respectively.
-
-Read more about the Secure Message's cryptographic internals [here](/pages/secure-message-cryptosystem/).
-
-#### Secure Message example
-
-```
-use themis::secure_message::SecureMessage;
-use themis::keygen::gen_ec_key_pair;
-
-let key_pair = gen_ec_key_pair();
-
-let secure = SecureMessage::new(key_pair);
-
-let encrypted = secure.encrypt(b"message")?;
-let decrypted = secure.decrypt(&encrypted)?;
-assert_eq!(decrypted, b"message");
-```
-
-_Description_:
-
-- `SecureMessage` – Secure Message encryption and decryption.
-- `SecureSign` – Secure Message signing.
-- `SecureVerify` – Secure Message verification.
-
-> **NOTE:** For signing/verifying make sure that you use keys from the same keypair: private key for signing message and public key for verifying message.
-
-
-### Secure Cell
-
-The **Secure Сell** functions provide the means of protection for arbitrary data contained in stores, i.e. database records or filesystem files. These functions provide both strong symmetric encryption and data authentication mechanisms.
+[**Secure Сell**](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+is a high-level cryptographic container
+aimed at protecting arbitrary data stored in various types of storage
+(e.g., databases, filesystem files, document archives, cloud storage, etc.)
+It provides both strong symmetric encryption and data authentication mechanism.
 
 The general approach is that given:
 
-- _input_: some source data to protect,
-- _key_: secret byte array,
-- _context_: plus an optional “context information”,
+  - _input:_ some source data to protect
+  - _secret:_ symmetric key or a password
+  - _context:_ and an optional “context information”
 
-Secure Cell functions will produce:
+Secure Cell will produce:
 
-- _cell_: the encrypted data,
-- _authentication tag_: some authentication data.
+  - _cell:_ the encrypted data
+  - _authentication token:_ some authentication data
 
-The purpose of the optional “context information” (i.e. a database row number or file name) is to establish a secure association between this context and the protected data. In short, even when the secret is known, if the context is incorrect, the decryption will fail.
+The purpose of the optional context information
+(e.g., a database row number or file name)
+is to establish a secure association between this context and the protected data.
+In short, even when the secret is known, if the context is incorrect then decryption will fail.
 
-The purpose of the authentication data is to verify that given a correct key (and context), the decrypted data is indeed the same as the original source data.
+The purpose of the authentication data is to validate
+that given a correct key or passphrase (and context),
+the decrypted data is indeed the same as the original source data,
+and the encrypted data has not been modified.
 
-The authentication data must be stored somewhere. The most convenient way is to simply append it to the encrypted data, but this is not always possible due to the storage architecture of an application. The Secure Cell functions offer different variants that address this issue.
+The authentication data must be stored somewhere.
+The most convenient way is to simply append it to the encrypted data,
+but this is not always possible due to the storage architecture of your application.
+Secure Cell offers variants that address this issue in different ways.
 
-By default, the Secure Cell uses the AES-256 encryption algorithm. The generated authentication data is 16 bytes long.
+By default, Secure Cell uses AES-256 for encryption.
+Authentication data takes additional 44 bytes when symmetric keys are used
+and 70 bytes in case the data is secured with a passphrase.
 
-Secure Cell is available in 3 modes:
+Secure Cell supports 2 kinds of secrets:
 
-- **[Seal mode](#secure-cell-seal-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Token protect mode](#secure-cell-token-protect-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Context imprint mode](#secure-cell-context-imprint-mode)**: length-preserving version of Secure Cell with no additional data stored. Should be used with care and caution.
+  - **Symmetric keys** are convenient to store and efficient to use for machines.
+    However, they are relatively long and hard for humans to remember.
 
-You can learn more about the underlying considerations, limitations, and features [here](/pages/secure-cell-cryptosystem/).
+  - **Passphrases**, in contrast, can be shorter and easier to remember.
 
-#### Secure Cell examples
+    However, passphrases are typically much less random than keys.
+    Secure Cell uses a [_key derivation function_][KDF] (KDF) to compensate for that
+    and achieves security comparable to keys with shorter passphrases.
+    This comes at a significant performance cost though.
 
-Here is how you use Secure Cell to seal away your data:
+    [KDF]: /docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions
 
-```rust
-use themis::secure_cell::SecureCell;
+Secure Cell supports 3 operation modes:
 
-let cell = SecureCell::with_key(&master_key)?.seal();
+  - **[Seal mode](#seal-mode)** is the most secure and easy to use.
+    Your best choice most of the time.
+    This is also the only mode that supports passphrases at the moment.
 
-let encrypted = cell.encrypt(b"source data")?;
-let decrypted = cell.decrypt(&encrypted)?;
-assert_eq!(decrypted, b"source data");
-```
+  - **[Token Protect mode](#token-protect-mode)** is just as secure, but a bit harder to use.
+    This is your choice if you need to keep authentication data separate.
 
-_Description_:
+  - **[Context Imprint mode](#context-imprint-mode)** is a length-preserving version of Secure Cell
+    with no additional data stored. Should be used carefully.
 
-- `SecureCell` – basic Secure Cell.
-    - `SecureCellTokenProtect` – Secure Cell in token protect operation mode.
-    - `SecureCellContextImprint` – Secure Cell in context imprint operation mode.
-    - `SecureCellSeal` – Secure Cell in sealing operation mode.
+Read more about
+[Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+to understand better the underlying considerations, limitations, and features of each mode.
 
-#### Secure Cell Token-protect Mode
+### Seal mode
 
-In this mode the input data is mixed with the provided context and encrypted, then the authentication token is computed and returned separately, along with the encrypted container. You will have to provide the authentication token later to decrypt the data, but it can be stored or transmitted separately. The encrypted data has the same length as the original input.
+[**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
+is the most secure and easy to use mode of Secure Cell.
+This should be your default choice unless you need specific features of the other modes.
 
-```rust
-use themis::secure_cell::SecureCell;
+<!-- See API reference here. -->
 
-let cell = SecureCell::with_key(&master_key)?.token_protect();
+Initialise a Secure Cell with a secret of your choice to start using it.
+Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
 
-let input = b"test input";
-let (output, token) = cell.encrypt(input)?;
-
-assert!(output.len() == input.len());
-```
-
-#### Secure Cell Context-Imprint Mode
-
-In this mode, the input data is mixed with the provided context and encrypted, but there is no authentication token. Use this mode when you have no additional storage available for the authentication data and you absolutely need the output data to have the same length as the original input.
-
-```rust
-use themis::secure_cell::SecureCell;
-
-let cell = SecureCell::with_key(&master_key)?.context_imprint();
-
-let input = b"test input";
-let output = cell.encrypt_with_context(input, b"context")?;
-
-assert!(output.len() == input.len());
-```
-
-Note that in context imprint mode you must provide non-empty context. Also keep in mind that Secure Cell cannot verify integrity and correctness of the decrypted data so you have to have some other means in place to validate the output.
-
-#### Secure Cell Seal mode
-
-In this mode the input data is mixed with the provided context and encrypted, then the authentication tag is appended to the data, resulting in a single encrypted and authenticated container. Note that the resulting sealed cell takes more space than the input data.
+{{< hint info >}}
+Each secret type has its pros and cons.
+Read about [Key derivation functions](/docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions) to learn more.
+{{< /hint >}}
 
 ```rust
+use themis::keys::SymmetricKey;
 use themis::secure_cell::SecureCell;
 
-let cell = SecureCell::with_key(&master_key)?.seal();
+let symmetric_key = SymmetricKey::new();
+let cell = SecureCell::with_key(&symmetric_key)?.seal();
 
-let input = b"test input";
-let output = cell.encrypt(input)?;
+// OR
 
-assert!(output.len() > input.len());
+let cell = SecureCell::with_passphrase("a password")?.seal();
 ```
 
-### Secure Session
+Now you can encrypt your data using the `encrypt_with_context` method:
 
-Secure Session is a sequence- and session- dependent, stateful messaging system. It is suitable for protecting long-lived peer-to-peer message exchanges where the secure data exchange is tied to a specific session context.
+```rust
+let plaintext = b"a message";
+let context = b"code sample";
 
-Secure Session operates in two stages:
-
-- **session negotiation** where the keys are established and cryptographic material is exchanged to generate ephemeral keys, and
-- **data exchange** where exchanging of messages can be carried out between peers.
-
-You can read a more detailed description of the process [here](/pages/secure-session-cryptosystem/).
-
-Put simply, Secure Session takes the following form:
-
-- Both clients and server construct a Secure Session object, providing:
-    - an arbitrary identifier,
-    - a private key, and
-    - a callback function that enables it to acquire the public key of the peers with which they may establish communication.
-- A client will generate a "connect request" and by whatever means it will dispatch that to the server.
-- A server will enter a negotiation phase in response to a client's "connect request".
-- Clients and servers will exchange messages until a "connection" is established.
-- Once a connection is established, clients and servers may exchange secure messages according to whatever application level protocol was chosen.
-
-#### Secure Session interface
-
-Secure Session usage is relatively involved so you can see a complete working example in the documentation for [client](https://github.com/cossacklabs/themis/blob/master/docs/examples/rust/secure_session_echo_client.rs) and [server](https://github.com/cossacklabs/themis/blob/master/docs/examples/rust/secure_session_echo_server.rs).
-
-To sum it up, you begin by implementing a `SecureSessionTransport`. You have to implement at least the `get_public_key_for_id` method and may want to implement some others. Then you acquire the asymmetric key pairs and distribute the public keys associated with peer IDs — arbitrary byte strings used to identify communicating Secure Sessions. With that, you can create an instance of SecureSession on both the client and the server.
-
-Next, you go through the negotiation stage using `connect` and `negotiate` methods until the connection `is_established`. After that, the Secure Sessions are ready for data exchange which is performed using `send` and `receive` methods.
-
-There is also an alternative buffer-oriented API.
-
-#### Secure Session callback API
-
-> **NOTE:** SecureSessionTransport is an interface you need to provide for Secure Session operation. The only required method is `get_public_key_for_id`. It is required for public key authentication. Other methods are optional, you can use Secure Session without them, but some functionality may be unavailable.
-
-Secure Session only provides security services and doesn’t do actual network communication. In fact, Secure Session is decoupled and independent from any networking implementation. It is your responsibility to provide network transport for Secure Session using the `SecureSessionTransport` trait. There are two types of APIs available: callback API and buffer-aware API. You can choose whatever API is more suitable for your application, or you can even mix them when appropriate.
-
-##### Callback API
-
-With the callback API, you delegate network communication to Secure Session. In order to use it, you have to implement the `send_data` and `receive_data` callbacks of SecureSessionTransport. Then you use `connect` and `negotiate` methods to negotiate and establish a connection. After that, `send` and `receive` methods can be used for data exchange. Secure Session will synchronously call the provided transport methods when necessary to perform network communication.
-
-There is an [example of server using the callback API](https://github.com/cossacklabs/themis/blob/master/docs/examples/rust/secure_session_echo_server.rs) available.
-
-##### Buffer-aware API
-
-With the buffer-aware API, you are responsible for transporting Secure Session messages between peers. Secure Session does not use `send_data` and `receive_data` callbacks in this mode. Instead, the `connect_request` and `negotiate_reply` methods return and receive data buffers that have to be exchanged between peers via some external transport (e.g., TLS). Similarly, `wrap` and `unwrap` methods are used to encrypt and decrypt data exchange messages after the connection has been negotiated. They too accept plaintext messages and return encrypted containers or vice versa.
-
-There is an [example of a using the buffer-aware API](https://github.com/cossacklabs/themis/blob/master/docs/examples/rust/secure_session_echo_client.rs) available.
-
-### Secure Comparator
-
-Secure Comparator is an interactive protocol for two parties that compares whether they share the same secret or not. It is built around a [Zero Knowledge Proof](https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html)-based protocol ([Socialist Millionaire's Protocol](https://en.wikipedia.org/wiki/Socialist_millionaires)), with a number of [security enhancements](https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf).
-
-Secure Comparator is transport-agnostic and only requires the user(s) to pass messages in a certain sequence. The protocol itself is ingrained into the functions and requires minimal integration efforts from the developer.
-
-#### Secure Comparator workflow
-
-Secure Comparator has two parties — called "client" and "server" — the only difference between them is in who starts the comparison.
-
-Before initiating the protocol both parties should append their secrets to be compared. This can be done incrementally so even multi-gigabyte data sets can be compared with ease.
-
+let encrypted = cell.encrypt_with_context(plaintext, context)?;
 ```
+
+The _associated context_ argument is optional, it can be empty
+(or use `encrypt` which accept just the plaintext).
+
+Seal mode produces encrypted cells that are slightly longer than the input:
+
+```rust
+assert!(encrypted.len() > plaintext.len());
+```
+
+You can decrypt the data back using the `decrypt_with_context` method
+(or `decrypt` if there is no associated context):
+
+```rust
+match cell.decrypt_with_context(encrypted, context) {
+    Ok(decrypted) => {
+        // process decrypted data
+    }
+    Err(error) => {
+        // handle decryption failure
+    }
+}
+```
+
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will return an error if those are incorrect or if the encrypted data was corrupted.
+
+### Token Protect mode
+
+[**Token Protect mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#token-protect-mode)
+should be used if you cannot allow the length of the encrypted data to grow
+but have additional storage available elsewhere for the authentication token.
+Other than that,
+Token Protect mode has the same security properties as the Seal mode.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Token Protect mode supports only [symmetric keys](#symmetric-keys).
+
+```rust
+use themis::keys::SymmetricKey;
+use themis::secure_cell::SecureCell;
+
+let symmetric_key = SymmetricKey::new();
+
+let cell = SecureCell::with_key(&symmetric_key)?.token_protect();
+```
+
+Now you can encrypt your data using the `encrypt_with_context` method:
+
+```rust
+let plaintext = b"a message";
+let context = b"code sample";
+
+let (encrypted, token) = cell.encrypt_with_context(plaintext, context)?;
+```
+
+The _associated context_ argument is optional, it can be empty
+(or use `encrypt` which accept just the plaintext).
+
+Token Protect mode produces encrypted text and authentication token separately.
+Encrypted data has the same length as the input:
+
+```rust
+assert!(encrypted.len() == plaintext.len());
+```
+
+You need to save both the encrypted data and the token, they are necessary for decryption.
+Use the `decrypt_with_context` method for that
+(or `decrypt` if there is no associated context):
+
+```rust
+match cell.decrypt_with_context(encrypted, token, context) {
+    Ok(decrypted) => {
+        // process decrypted data
+    }
+    Err(error) => {
+        // handle decryption failure
+    }
+}
+```
+
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will return an error if those are incorrect
+or if the data or the authentication token was corrupted.
+
+### Context Imprint mode
+
+[**Context Imprint mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#context-imprint-mode)
+should be used if you absolutely cannot allow the length of the encrypted data to grow.
+This mode is a bit harder to use than the Seal and Token Protect modes.
+Context Imprint mode also provides slightly weaker integrity guarantees.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Context Imprint mode supports only [symmetric keys](#symmetric-keys).
+
+```rust
+use themis::keys::SymmetricKey;
+use themis::secure_cell::SecureCell;
+
+let symmetric_key = SymmetricKey::new();
+
+let cell = SecureCell::with_key(&symmetric_key)?.context_imprint();
+```
+
+Now you can encrypt your data using the `encrypt_with_context` method:
+
+```rust
+let plaintext = b"a message";
+let context = b"code sample";
+
+let encrypted = cell.encrypt_with_context(plaintext, context)?;
+```
+
+{{< hint info >}}
+**Note:**
+Context Imprint mode **requires** associated context for encryption and decryption.
+For the highest level of security, use a different context for each data piece.
+{{< /hint >}}
+
+Context Imprint mode produces encrypted text of the same length as the input:
+
+```rust
+assert!(encrypted.len() == plaintext.len());
+```
+
+You can decrypt the data back using the `decrypt_with_context` method:
+
+```rust
+let decrypted = cell.decrypt_with_context(encrypted, context)?;
+if !correct(&decrypted) {
+    // handle decryption failure
+}
+```
+
+{{< hint warning >}}
+**Warning:**
+In Context Imprint mode, Secure Cell cannot validate correctness of the decrypted data.
+If an incorrect secret or context is used, or if the data has been corrupted,
+Secure Cell will return garbage output without reporting an error.
+{{< /hint >}}
+
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+You should also do some sanity checks after decryption.
+
+## Secure Message
+
+[**Secure Message**](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+is a lightweight container
+that can help deliver some message or data to your peer in a secure manner.
+It provides a sequence-independent, stateless, contextless messaging system.
+This may be preferred in cases that don't require frequent sequential message exchange
+and/or in low-bandwidth contexts.
+
+Secure Message is secure enough to exchange messages from time to time,
+but if you'd like to have [_perfect forward secrecy_](https://en.wikipedia.org/wiki/Forward_secrecy)
+and higher security guarantees,
+consider using [Secure Session](#secure-session) instead.
+
+Secure Message offers two modes of operation:
+
+  - In [**Sign–Verify mode**](#signature-mode),
+    the message is signed by the sender using their private key,
+    then it is verified by the recipient using the sender's public key.
+
+    The message is packed in a suitable container and signed with an appropriate algorithm,
+    based on the provided keypair type.
+    Note that the message is _not encrypted_ in this mode.
+
+  - In [**Encrypt–Decrypt mode**](#encryption-mode),
+    the message will be additionally encrypted
+    with an intermediate symmetric key using [Secure Cell](#secure-cell) in Seal mode.
+
+    The intermediate key is generated in such way that only the recipient can recover it.
+    The sender needs to provide their own private key
+    and the public key of the intended recipient.
+    Correspondingly, to get access to the message content,
+    the recipient will need to use their private key
+    along with the public key of the expected sender.
+
+Read more about
+[Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+to understand better the underlying considerations, limitations, and features of each mode.
+
+### Signature mode
+
+[**Signature mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#signed-messages)
+only adds cryptographic signatures over the messages,
+enough for anyone to authenticate them and prevent tampering
+but without additional confidentiality guarantees.
+
+To begin, the sender needs to generate an [asymmetric keypair](#asymmetric-keypairs).
+The private key stays with the sender and the public key should be published.
+Any recipient with the public key will be able to verify messages
+signed by the sender which owns the corresponding private key.
+
+The **sender** initialises Secure Message using their private key:
+
+```rust
+use themis::keygen;
+use themis::secure_message::SecureSign;
+
+let (private_key, public_key) = keygen::gen_ec_key_pair().split();
+
+let secure_message = SecureSign::new(private_key);
+```
+
+Messages can be signed using the `sign` method:
+
+```rust
+let message = b"example message";
+
+let signed = secure_message.sign(&message)?;
+```
+
+To verify messages, the **recipient** first has to obtain the sender's public key.
+Secure Message should be initialised with only the public key:
+
+```rust
+use themis::keys::PublicKey;
+use themis::secure_message::SecureVerify;
+
+let peer_public_key = PublicKey::try_from_slice(...)?;
+
+let secure_message = SecureVerify::new(peer_public_key);
+```
+
+Now the receipent may verify messages signed by the sender using the `verify` method:
+
+```rust
+match secure_message.verify(&signed) {
+    Ok(verified) => {
+        // process verified message
+    }
+    Err(error) => {
+        // handle verification failure
+    }
+}
+```
+
+Secure Message will return an error if the message has been modified since the sender signed it,
+or if the message has been signed by someone else, not the expected sender.
+
+### Encryption mode
+
+[**Encryption mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#encrypted-messages)
+not only certifies the integrity and authenticity of the message,
+it also guarantees its confidentialty.
+That is, only the intended recipient is able to read the encrypted message,
+as well as to verify that it has been signed by the expected sender and arrived intact.
+
+For this mode, both the sender and the recipient—let's call them
+Alice and Bob—each need to generate an [asymmetric keypair](#symmetric-keypairs) of their own,
+and then send their public keys to the other party.
+
+{{< hint info >}}
+**Note:**
+Be sure to authenticate the public keys you receive to prevent Man-in-the-Middle attacks.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
+
+**Alice** initialises Secure Message with her private key and Bob's public key:
+
+```rust
+use themis::keys::PublicKey;
+use themis::keygen;
+use themis::secure_message::SecureSign;
+
+let (alice_private_key, alice_public_key) = keygen::gen_ec_key_pair().split();
+let bob_public_key = PublicKey::try_from_slice(...)?; // received securely
+
+let alice_secure_message =
+    SecureMessage::new(alice_private_key, bob_public_key);
+```
+
+Now Alice can encrypt messages for Bob using the `encrypt` method:
+
+```rust
+let message = b"example message";
+
+let encrypted = alice_secure_message.encrypt(message)?;
+```
+
+**Bob** initialises Secure Message with his private key and Alice's public key:
+
+```rust
+let (bob_private_key, bob_public_key) = keygen::gen_ec_key_pair().split();
+let alice_public_key = PublicKey::try_from_slice(...)?; // received securely
+
+let bob_secure_message =
+    SecureMessage::new(bob_private_key, alice_public_key);
+```
+
+With this, Bob is able to decrypt messages received from Alice
+using the `decrypt` method:
+
+```rust
+match secure_message.decrypt(&encrypted) {
+    Ok(decrypted) => {
+        // process decrypted message
+    }
+    Err(error) => {
+        // handle decryption failure
+    }
+}
+```
+
+Bob's Secure Message will return an error
+if the message has been modified since Alice encrypted it;
+or if the message was encrypted by Carol, not by Alice;
+or if the message was actually encrypted by Alice but *for Carol* instead, not for Bob.
+
+## Secure Session
+
+[**Secure Session**](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+is a lightweight protocol for securing any kind of network communication,
+on both private and public networks, including the Internet.
+It operates on the 5th layer of the network OSI model (the session layer).
+
+Secure Session provides a stateful, sequence-dependent messaging system.
+This approach is suitable for protecting long-lived peer-to-peer message exchanges
+where the secure data exchange is tied to a specific session context.
+
+Communication over Secure Session consists of two stages:
+
+  - **Session negotiation** (key agreement),
+    during which the peers exchange their cryptographic material and authenticate each other.
+    After a successful mutual authentication,
+    each peer derives a session-shared secret and other auxiliary data
+    (session ID, sequence numbers, etc.)
+
+  - **Actual data exchange**,
+    when the peers securely exchange data provided by higher-layer application protocols.
+
+Secure Session supports two operation modes:
+
+  - [**Buffer-aware API**](#buffer-aware-api)
+    in which encrypted messages are handled explicitly, with data buffers you provide.
+  - [**Callback-oriented API**](#callback-oriented-api)
+    in which Secure Session handles buffer allocation implicitly
+    and uses callbacks to notify about incoming messages or request sending outgoing messages.
+
+Read more about
+[Secure Session cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+to understand better the underlying considerations,
+get an overview of the protocol and its features,
+etc.
+
+### Setting up Secure Session
+
+Secure Session has two parties called “client” and “server” for the sake of simplicity,
+but they could be more precisely called “initiator” and “acceptor” –
+the only difference between the two is in who starts the communication.
+After the session is established, either party can send messages to their peer whenever it wishes to.
+
+{{< hint info >}}
+Take a look at code samples in the [`docs/examples/rust`](https://github.com/cossacklabs/themis/tree/master/docs/examples/rust) directory on GitHub.
+There you can find examples of Secure Session setup and usage in all modes.
+{{< /hint >}}
+
+First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
+and exchange their public keys.
+The private keys should never be shared with anyone else.
+
+{{< hint warning >}}
+**Note:**
+Currently, Secure Session in RustThemis supports only Elliptic Curve keys.
+RSA keys are not supported.
+[Please tell us](mailto:dev@cossacklabs.com)
+if this is a problem for your application.
+{{< /hint >}}
+
+Each party should also choose a unique *peer ID* –
+arbitrary byte sequence identifying their public key.
+Read more about peer IDs in [Secure Session cryptosystem overview](/docs/themis/crypto-theory/crypto-systems/secure-session/#peer-ids-and-keys).
+The peer IDs need to be exchanged along with the public keys.
+
+To identify peers, Secure Session uses a **callback interface**.
+It calls the `get_public_key_for_id` method to locate a public key associated with presented peer ID.
+Typically, each peer keeps some sort of a database of known public keys
+and fulfills Secure Session requests from that database.
+
+```rust
+use themis::keys::EcdsaPublicKey;
+use themis::secure_session::SecureSessionTransport;
+
+struct SessionCallbacks {
+    // ...
+}
+
+impl SecureSessionTransport for SessionCallbacks {
+    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey> {
+        // Retrieve public key for peer "id" from the trusted storage.
+        if !found {
+            return None;
+        }
+        Some(public_key)
+    }
+}
+```
+
+Each peer initialises Secure Session with their ID, their private key,
+and an instance of the callback interface:
+
+```rust
+use themis::keygen;
+use themis::secure_session::SecureSession;
+
+let peer_id = b"Alice";
+let (private_key, public_key) = keygen::gen_ec_key_pair().split();
+let callbacks = SessionCallbacks::new(...);
+
+let mut session = SecureSession::new(peer_id, private_key, callbacks)?;
+```
+
+{{< hint info >}}
+**Note:**
+The same callback interface may be shared by multiple Secure Session instances,
+provided it is correctly synchronised.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+#### Transport callbacks
+
+If you wish to use the **callback-oriented API** of Secure Session,
+you have to implement two additional methods of the callback interface:
+
+```rust
+use themis::secure_session::TransportError;
+
+impl SecureSessionTransport for TransportCallbacks {
+    fn send_data(&mut self, data: &[u8]) -> Result<usize, TransportError> {
+        // Send "data" to the peer over the network.
+        // Return an error if that fails.
+        Ok(data.len())
+    }
+
+    fn receive_data(&mut self, data: &mut [u8]) -> Result<usize, TransportError> {
+        // Receive a message for peer into the provided buffer.
+        // Return the actual length of the message, or an error.
+        Ok(used_bytes_of_data)
+    }
+
+    fn get_public_key_for_id(&mut self, id: &[u8]) -> Option<EcdsaPublicKey> {
+        // Retrieve public key for peer "id" from the trusted storage.
+    }
+}
+```
+
+{{< hint warning >}}
+**Warning:**
+In send–receive mode, each Secure Session needs its own instance of transport callback interface.
+The same instance cannot be shared by multiple sessions.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+### Buffer-aware API
+
+[**Buffer-aware API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#buffer-aware-api)
+(aka *wrap–unwrap* mode)
+is easier to integrate into existing application with established network processing path.
+Here the application handles message buffers explicitly.
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
+
+```rust
+let request = session.connect_request()?
+
+send_to_peer(&requst);
+```
+
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
+
+```rust
+loop {
+    let reply = receive_from_peer();
+    let response = session.negotiate_reply(&reply)?;
+    if session.is_established() {
+        break;
+    }
+    send_to_peer(&response);
+}
+```
+
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+In buffer-aware API, the messages are wrapped into Secure Session protocol and sent separately:
+
+```rust
+let message = b"a message";
+
+let encrypted_message = session.wrap(&message)?;
+
+send_to_peer(&encrypted_message);
+```
+
+You can wrap multiple messages before sending them out.
+Encrypted messages are independent.
+
+{{< hint info >}}
+**Note:**
+Secure Session allows occasional message loss,
+slight degree of out-of-order delivery, and some duplication.
+However, it is still a sequence-dependent protocol.
+Do your best to avoid interrupting the message stream.
+{{< /hint >}}
+
+After receiving an encrypted message, you need to unwrap it:
+
+```rust
+let encrypted_message = receive_from_peer();
+
+match session.unwrap(&encrypted_message) {
+    Ok(decrypted_message) => {
+        // process a message
+    }
+    Err(error) => {
+        // handle corrupted messages
+    }
+}
+```
+
+Secure Session ensures message integrity and will return an error
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
+
+### Callback-oriented API
+
+[**Callback-oriented API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+(aka *send–receive* mode)
+uses Secure Session as a framework for network communication, handling data buffers implicitly.
+It allows for simpler messaging code at an expense of more complex setup code.
+
+{{< hint info >}}
+**Note:**
+Remember to [configure transport callbacks](#transport-callbacks) for Secure Session,
+they are required to use the callback-oriented API.
+{{< /hint >}}
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
+
+```rust
+session.connect()?;
+```
+
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
+
+```rust
+while !session.is_established() {
+    session.negotiate()?;
+}
+```
+
+Note that actual networking happens implicitly, within the Secure Session object
+which calls appropriate transport callbacks to send and receive data over the network.
+
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+Send messages as if the Secure Session were a network socket,
+using the `send` method:
+
+```rust
+let message = b"a message";
+
+session.send(&message)?;
+```
+
+Secure Session encrypts the message, wraps it into the protocol,
+and synchronously calls the `send` transport callback to ship the message out.
+
+The receiving side uses the `receive` method to receive messages:
+
+```rust
+let message = session.receive(MAX_LENGTH)?;
+```
+
+Secure Session synchronously calls the `receive` transport callback
+to wait for the next message, then unwraps and decrypts it,
+and returns already decrypted message to the application.
+
+Secure Session ensures message integrity and will return an erro
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
+
+## Secure Comparator
+
+[**Secure Comparator**](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+is an interactive protocol for two parties that compares whether they share the same secret or not.
+It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
+([Socialist Millionaire's Protocol][SMP]),
+with a number of [security enhancements][paper].
+
+[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
+[paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
+
+Secure Comparator is transport-agnostic.
+That is, the implementation handles all intricacies of the protocol,
+but the application has to supply networking capabilities to exchange the messages.
+
+Read more about
+[Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+to understand better the underlying considerations,
+get an overview of the protocol, etc.
+
+### Comparing secrets
+
+Secure Comparator has two parties called “client” and “server” for the sake of simplicity,
+but the only difference between the two is in who initiates the comparison.
+
+Both parties start by initialising Secure Comparator with the secret they need to compare:
+
+```rust
 use themis::secure_comparator::SecureComparator;
 
 let mut comparison = SecureComparator::new();
 
-comparison.append_secret(b"999-04-1234")?;
+comparison.append_secret("shared secret")?;
 ```
 
-After that, the client initiates the comparison and runs a loop:
+The client initiates the protocol and sends the message to the server:
 
 ```rust
-let mut request = comparison.begin_compare()?;
+let first_message = comparison.begin_compare()?;
 
-while !comparison.is_complete() {
-    send(&request);         // This function should send the `request` to the server.
-    let reply = receive();  // This function should receive a `reply` from the server.
-
-    request = comparison.proceed_compare(&reply)?;
-}
-
-if !comparison.result()? {
-    unimplemented!("handle failed comparison here");
-}
+send_to_peer(&first_message);
 ```
 
-While the server does almost the same thing:
+Now, each peer waits for a message from the other one,
+passes it to Secure Comparator, and gets a response that needs to be sent back.
+The comparison is complete when the response is empty:
 
 ```rust
 while !comparison.is_complete() {
-    // This function should receive a `request` from the client.
-    let request = receive();
-
-    let reply = comparison.proceed_compare(&request)?;
-
-    send(&reply);   // This function should send the `reply` to the client.
-}
-
-if !comparison.result()? {
-    unimplemented!("handle failed comparison here");
+    let request = receive_from_peer();
+    let response = comparison.proceed_compare(&request)?;
+    if !response.is_empty() {
+        send_to_peer(&response);
+    }
 }
 ```
 
-Both the server and the client use `result` to get the comparison result after it `is_complete`.
+Once the comparison is complete, you can get the results (on each side):
 
-
-## Developing Themis for Rust
-
-Rust-Themis uses standard Cargo tooling
-so developing the library itself is equally easy.
-Check out the latest source code from GitHub:
-
-```
-git clone https://github.com/cossacklabs/themis.git
+```rust
+if comparison.result()? {
+    // shared secrets match
+}
 ```
 
-Then you can go ahead and, for example, build and run the test suite:
-
-```
-cargo test
-```
-
-or build and read the latest API documentation:
-
-```
-cargo doc --open
-```
-
-You can test your application with your local working copy of Themis
-by adding the following override to the application's Cargo.toml file:
-
-```toml
-[patch.crates-io]
-themis = { path = "/path/to/themis/repo" }
-```
-
-We use the following Cargo tools to maintain the quality of the code base:
-
-  - [**rustfmt:**](https://github.com/rust-lang/rustfmt)
-    automated code formatting keeps the code style consistent.
-
-  - [**clippy:**](https://github.com/rust-lang/rust-clippy)
-    static code analyzer detects possible issues early on.
-
-If you wish to help develop and expand Rust-Themis,
-we strongly advise you to install and use these tools.
-
-Please follow the general contribution process
-[outlined in our guide](/pages/documentation-themis/#contributing-contacts-assistance).
+Secure Comparator performs consistency checks on the protocol messages
+and will return an error if they were corrupted.
+But if the other party fails to demonstrate that it has a matching secret,
+Secure Comparator will only return a negative result.

--- a/docs/themis/languages/swift/features.md
+++ b/docs/themis/languages/swift/features.md
@@ -603,6 +603,14 @@ SwiftThemis supports only
 (aka *wrap–unwrap* mode).
 It is easy to integrate into existing applications with established network processing path.
 
+{{< hint info >}}
+**Note:**
+Support for [callback-oriented API](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+in SwiftThemis is currently in development.
+If you find that it might be a good fit for your use case,
+please [let us know](mailto:dev@cossacklabs.com).
+{{< /hint >}}
+
 #### Establishing connection
 
 The client initiates the connection and sends the first request to the server:

--- a/docs/themis/languages/swift/features.md
+++ b/docs/themis/languages/swift/features.md
@@ -821,7 +821,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```swift
 if client.status() == TSComparatorStateType.comparatorMatch {
-    // secrets match
+    // shared secrets match
 }
 ```
 

--- a/docs/themis/languages/swift/features.md
+++ b/docs/themis/languages/swift/features.md
@@ -133,13 +133,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/swift/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -197,8 +199,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -251,8 +251,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -343,6 +341,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/swift/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -502,6 +504,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/swift/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -776,6 +782,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/swift/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/swift/features.md
+++ b/docs/themis/languages/swift/features.md
@@ -289,8 +289,8 @@ You can decrypt the data back using the `decrypt` method:
 ```swift
 let decryptedMessage = try! cell.decrypt(encryptedMessage,
                                          context: context)
-if looksCorrect(decryptedMessage) {
-    // process decrypted data
+if !correct(decryptedMessage) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/swift/features.md
+++ b/docs/themis/languages/swift/features.md
@@ -5,52 +5,59 @@ title:  Features
 
 # Features of SwiftThemis
 
-<a id="importing-themis"></a>
+After you have [installed SwiftThemis](../installation/),
+it is ready to use in your application!
+
 ## Using Themis
 
-In order to use Themis, you need to import it first:
+In order to use SwiftThemis, you need to import its module:
 
 ```swift
 import themis
 ```
 
-### Key generation
+## Key generation
 
-#### Asymmetric keypair generation
+### Asymmetric keypairs
 
 Themis supports both Elliptic Curve and RSA algorithms for asymmetric cryptography.
 Algorithm type is chosen according to the generated key type.
-Asymmetric keys are necessary for [Secure Message](/pages/secure-message-cryptosystem/) and [Secure Session](/pages/secure-session-cryptosystem/) objects.
+Asymmetric keys are used by [Secure Message](#secure-message)
+and [Secure Session](#secure-session) objects.
 
-For learning purposes, you can play with [Themis Interactive Simulator](/simulator/interactive/) to get the keys and simulate the whole client-server communication.
+For learning purposes,
+you can play with [Themis Interactive Simulator](/docs/themis/debugging/themis-server/)
+to use the keys and simulate the whole client-server communication.
 
-> ⚠️ **WARNING:**
-> When you distribute private keys to your users, make sure the keys are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When using public keys of other peers, make sure they come from trusted sources
+to prevent Man-in-the-Middle attacks.
 
-> **NOTE:** When using public keys of other peers, make sure they come from trusted sources.
+When handling private keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
-You can easily generate asymmetric keypairs the following way:
+To generate asymmetric keypairs, use:
 
 ```swift
 // Use ".RSA" to generate RSA keys instead
-let keypairGenerator = TSKeyGen(algorithm: .EC)!
+let keypair = TSKeyGen(algorithm: .EC)!
 
-let privateKey: Data = keypairGenerator.privateKey!
-let publicKey: Data = keypairGenerator.publicKey!
+let privateKey: Data = keypair.privateKey!
+let publicKey: Data = keypair.publicKey!
 ```
 
-#### Symmetric key generation
+### Symmetric keys
 
 Themis uses highly efficient and secure AES algorithm for symmetric cryptography.
-A symmetric key is necessary for [Secure Cell](/pages/secure-cell-cryptosystem/) objects.
+A symmetric key is necessary for [Secure Cell](#secure-cell) objects.
 
-> **NOTE:** Symmetric key generation API will become available for Swift with Themis 0.13.0. For now, use common sense or consult [the wisdom of the Internet](https://stackoverflow.com/search?q=generate+cryptographically+secure+keys).
-
-<!--
-> ⚠️ **WARNING:**
-> When you store generated keys, make sure they are sufficiently protected.
-> You can find the guidelines [here](/pages/documentation-themis/#key-management).
+{{< hint warning >}}
+**Warning:**
+When handling symmetric keys of your users, make sure the keys are sufficiently protected.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
 
 To generate symmetric keys, use:
 
@@ -58,515 +65,759 @@ To generate symmetric keys, use:
 let masterKey: Data = TSGenerateSymmetricKey()!
 ```
 
--->
+## Secure Cell
 
-### Secure Message
-
-The Secure Message functions provide a sequence-independent, stateless, contextless messaging system. This may be preferred in cases that don't require frequent sequential message exchange and/or in low-bandwidth contexts. This is secure enough to exchange messages from time to time, but if you'd like to have Perfect Forward Secrecy and higher security guarantees, consider using [Secure Session](#secure-session) instead.
-
-The Secure Message functions offer two modes of operation:
-
-In **Sign/Verify** mode, the message is signed using the sender's private key and is verified by the receiver using the sender's public key. The message is packed in a suitable container and ECDSA is used by default to sign the message (when RSA key is used, RSA+PSS+PKCS#7 digital signature is used).
-
-In **Encrypt/Decrypt** mode, the message will be encrypted with a randomly generated key (in RSA) or a key derived by ECDH (in ECDSA), via symmetric algorithm with Secure Cell in seal mode (keys are 256 bits long).
-
-The mode is selected by using appropriate methods. The sender uses `wrap` and `unwrap` methods for encrypt/decrypt mode. A valid public key of the receiver and a private key of the sender are required in this mode. For sign/verify mode `sign` and `verify` methods should be used. They only require a private key for signing and a public key for verification respectively.
-
-Read more about the Secure Message's cryptographic internals [here](/pages/secure-message-cryptosystem/).
-
-#### Encryption
-
-To encrypt a message use client private key and server public key and convert them to `NSData`:
-
-```swift
-// base64-encoded keys
-let serverPublicKeyString = "VUVDMgAAAC2ELbj5Aue5xjiJWW3P2KNrBX+HkaeJAb+Z4MrK0cWZlAfpBUql"
-let clientPrivateKeyString = "UkVDMgAAAC13PCVZAKOczZXUpvkhsC+xvwWnv3CLmlG0Wzy8ZBMnT+2yx/dg"
-
-guard
-    let serverPublicKey = Data(base64Encoded: serverPublicKeyString),
-    let clientPrivateKey = Data(base64Encoded: clientPrivateKeyString)
-else {
-    print("failed to decode base64")
-    return
-}
-```
-
-Initialise encrypter:
-
-```swift
-let encrypter = TSMessage(inEncryptModeWithPrivateKey: clientPrivateKey,
-                          peerPublicKey: serverPublicKey)!
-```
-
-Encrypt message:
-
-```swift
-let message = "- Knock, knock.\n- Who’s there?\n*very long pause...*\n- Java."
-
-do {
-    let encryptedMessage = try encrypter.wrap(message.data(using: .utf8))
-    print("encrypted message: \(encryptedMessage)")
-}
-catch let error as NSError {
-    print("failed to encrypt message: \(error)")
-    return
-}
-```
-
-Result (the encryption result for the same data chunk is different every time and can't be used as a test):
-
-```
-encrypted message: <20270426 53000000 00010140 0c000000 10000000 1f000000 ad443c21 d6d7df98 a101e48b b3757b04 c5710e04 5720b3c2 fe674f54 73e10ad4 ee722d3e 42244b6d c5099ac4 89dfda90 75fae62a aa733872 c8180d>
-```
-
-#### Decryption
-
-Use the server private key and the client public key for decryption:
-
-```swift
-// base64 encoded keys
-let serverPrivateKeyString = "UkVDMgAAAC1FsVa6AMGljYqtNWQ+7r4RjXTabLZxZ/14EXmi6ec2e1vrCmyR"
-let clientPublicKeyString = "VUVDMgAAAC1SsL32Axjosnf2XXUwm/4WxPlZauQ+v+0eOOjpwMN/EO+Huh5d"
-
-guard
-    let serverPrivateKey = Data(base64Encoded: serverPrivateKeyString),
-    let clientPublicKey = Data(base64Encoded: clientPublicKeyString)
-else {
-    print("failed to decode base64")
-    return
-}
-
-```
-
-Initialise decrypter:
-
-```swift
-let decrypter = TSMessage(inEncryptModeWithPrivateKey: serverPrivateKey,
-                          peerPublicKey: clientPublicKey)!
-```
-
-Decrypt message:
-
-```swift
-do {
-    let decryptedMessage = try decrypter.unwrapData(encryptedMessage)
-    print("decrypted message: \(decryptedMessage)")
-}
-catch let error as NSError {
-    print("failed to decrypt message: \(error)")
-    return
-}
-```
-
-Result:
-
-```
-decrypted message: - Knock, knock.\n- Who’s there?\n*very long pause...*\n- Java.!
-```
-
-#### Sign / Verify
-
-The only code difference between sign/verify and encrypt/decrypt mode is in the initialiser:
-
-```swift
-let signer = TSMessage(inSignVerifyModeWithPrivateKey: privateKey,
-                       peerPublicKey: nil)!
-
-let verifier = TSMessage(inSignVerifyModeWithPrivateKey: nil,
-                         peerPublicKey: publicKey)!
-```
-
-Use private key for signing message and public key from the same keypair for verifying message.
-
-### Secure Cell
-
-The **Secure Сell** functions provide the means of protection for arbitrary data contained in stores, i.e. database records or filesystem files. These functions provide both strong symmetric encryption and data authentication mechanisms.
+[**Secure Сell**](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+is a high-level cryptographic container
+aimed at protecting arbitrary data stored in various types of storage
+(e.g., databases, filesystem files, document archives, cloud storage, etc.)
+It provides both strong symmetric encryption and data authentication mechanism.
 
 The general approach is that given:
 
-- _input_: some source data to protect,
-- _key_: secret byte array,
-- _context_: plus an optional “context information”,
+  - _input:_ some source data to protect
+  - _secret:_ symmetric key or a password
+  - _context:_ and an optional “context information”
 
-Secure Cell functions will produce:
+Secure Cell will produce:
 
-- _cell_: the encrypted data,
-- _authentication tag_: some authentication data.
+  - _cell:_ the encrypted data
+  - _authentication token:_ some authentication data
 
-The purpose of the optional “context information” (i.e. a database row number or file name) is to establish a secure association between this context and the protected data. In short, even when the secret is known, if the context is incorrect, the decryption will fail.
+The purpose of the optional context information
+(e.g., a database row number or file name)
+is to establish a secure association between this context and the protected data.
+In short, even when the secret is known, if the context is incorrect then decryption will fail.
 
-The purpose of the authentication data is to verify that given a correct key (and context), the decrypted data is indeed the same as the original source data.
+The purpose of the authentication data is to validate
+that given a correct key or passphrase (and context),
+the decrypted data is indeed the same as the original source data,
+and the encrypted data has not been modified.
 
-The authentication data must be stored somewhere. The most convenient way is to simply append it to the encrypted data, but this is not always possible due to the storage architecture of an application. The Secure Cell functions offer different variants that address this issue.
+The authentication data must be stored somewhere.
+The most convenient way is to simply append it to the encrypted data,
+but this is not always possible due to the storage architecture of your application.
+Secure Cell offers variants that address this issue in different ways.
 
-By default, the Secure Cell uses the AES-256 encryption algorithm. The generated authentication data is 16 bytes long.
+By default, Secure Cell uses AES-256 for encryption.
+Authentication data takes additional 44 bytes when symmetric keys are used
+and 70 bytes in case the data is secured with a passphrase.
 
-Secure Cell is available in 3 modes:
+Secure Cell supports 2 kinds of secrets:
 
-- **[Seal mode](#secure-cell-seal-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Token protect mode](#secure-cell-token-protect-mode)**: the most secure and user-friendly mode. Your best choice most of the time.
-- **[Context imprint mode](#secure-cell-context-imprint-mode)**: length-preserving version of Secure Cell with no additional data stored. Should be used with care and caution.
+  - **Symmetric keys** are convenient to store and efficient to use for machines.
+    However, they are relatively long and hard for humans to remember.
 
-You can learn more about the underlying considerations, limitations, and features [here](/pages/secure-cell-cryptosystem/).
+  - **Passphrases**, in contrast, can be shorter and easier to remember.
 
-#### Initialising Secure Cell
+    However, passphrases are typically much less random than keys.
+    Secure Cell uses a [_key derivation function_][KDF] (KDF) to compensate for that
+    and achieves security comparable to keys with shorter passphrases.
+    This comes at a significant performance cost though.
 
-In order to initialise Secure Cell object, you will need to provide master key as Data:
+    [KDF]: /docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions
+
+Secure Cell supports 3 operation modes:
+
+  - **[Seal mode](#seal-mode)** is the most secure and easy to use.
+    Your best choice most of the time.
+    This is also the only mode that supports passphrases at the moment.
+
+  - **[Token Protect mode](#token-protect-mode)** is just as secure, but a bit harder to use.
+    This is your choice if you need to keep authentication data separate.
+
+  - **[Context Imprint mode](#context-imprint-mode)** is a length-preserving version of Secure Cell
+    with no additional data stored. Should be used carefully.
+
+Read more about
+[Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
+to understand better the underlying considerations, limitations, and features of each mode.
+
+### Seal mode
+
+[**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
+is the most secure and easy to use mode of Secure Cell.
+This should be your default choice unless you need specific features of the other modes.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
+
+{{< hint info >}}
+Each secret type has its pros and cons.
+Read about [Key derivation functions](/docs/themis/crypto-theory/crypto-systems/secure-cell/#key-derivation-functions) to learn more.
+{{< /hint >}}
 
 ```swift
-let masterKeyString = "ZG43anZDcWNFNWh6bU8yNWdsZjlsUzhaNlhkdzA1bXgK"
-let masterKeyData = Data(base64Encoded: masterKeyString)!
+let symmetricKey = TSGenerateSymmetricKey()!
+let cell = TSCellSeal(key: symmetricKey)!
+
+// OR
+
+let cell = TSCellSeal(passphrase: "a password")!
 ```
 
-#### Secure Cell Seal Mode
-
-Initialise encrypter/decrypter:
+Now you can encrypt your data using the `encrypt` method:
 
 ```swift
-guard let cellSeal = TSCellSeal(key: masterKeyData) else {
-    print("failed to initialize seal mode")
-    return
-}
+let plaintext: Data = ...
+let context: Data = ...
+
+let encrypted: Data = try! cell.encrypt(plaintext, context: context)
 ```
 
-Encryption:
+The _associated context_ argument is optional and can be omitted.
+
+Seal mode produces encrypted cells that are slightly longer than the input:
 
 ```swift
-let message = "all your base are belong to us"
-let context = "for the great justice"
-
-do {
-    // "context" is an optional parameter and may be omitted
-    let encryptedMessage = try cellSeal.wrap(message.data(using: .utf8)!,
-                                             context: context.data(using: .utf8)!)
-    print("encrypted message: \(encryptedMessage)")
-}
-catch let error as NSError {
-    print("failed to encrypt message: \(error)")
-    return
-}
+assert(encrypted.count > plaintext.count)
 ```
 
-Decryption:
+You can decrypt the data back using the `decrypt` method:
 
 ```swift
-do {
-    let decryptedMessage = try cellSeal.unwrapData(encryptedMessage,
-                                                   context: context.data(using: .utf8)!)
-    print("decrypted message: ", String(data: decryptedMessage, encoding: .utf8)!)
-}
-catch let error as NSError {
-    print("failed to decrypt message: \(error)")
-    return
-}
-```
-
-#### Secure Cell Token-Protect Mode
-
-Initialise encrypter/decrypter:
-
-```swift
-guard let cellToken = TSCellToken(key: masterKeyData) else {
-    print("failed to initialize token-protect mode")
-    return
-}
-```
-
-Encryption:
-
-```swift
-let message = "Roses are grey. Violets are grey."
-let context = "I'm a dog"
-
-var encryptedMessage: TSCellTokenEncryptedData = TSCellTokenEncryptedData()
-do {
-    // "context" is an optional parameter and may be omitted
-    let encryptedMessage = try cellToken.wrap(message.data(using: .utf8)!,
-                                              context: context.data(using: .utf8)!)
-    print("encrypted message: \(encryptedMessage.cipherText)")
-    print("authentication token: \(encryptedMessage.token)")
-}
-catch let error as NSError {
-    print("failed to encrypt: \(error)")
-    return
-}
-```
-
-Decryption:
-
-```swift
-do {
-    let decryptedMessage = try cellToken.unwrapData(encryptedMessage,
-                                                    context: context.data(using: .utf8)!)
-    print("decrypted message: ", String(data: decryptedMessage, encoding: .utf8)!)
-}
-catch let error as NSError {
-    print("failed to decrypt message: \(error)")
-    return
-}
-```
-
-#### Secure Cell Context-Imprint Mode
-
-Initialise encrypter/decrypter:
-
-```swift
-guard let contextImprint = TSCellContextImprint(key: masterKeyData) else {
-    print("failed to initialize context-imprint mode")
-    return
-}
-```
-
-Encryption:
-
-```swift
-let message = "Roses are red. My name is Dave. This poem makes no sense"
-let context = "Microwave"
-
-do {
-    // "context" is a REQUIRED parameter here
-    let encryptedMessage = try contextImprint.wrap(message.data(using: .utf8)!,
-                                                   context: context.data(using: .utf8)!)
-    print("encrypted message: \(encryptedMessage)")
-}
-catch let error as NSError {
-    print("failed to encrypt message: \(error)")
-    return
-}
-```
-
-Decryption:
-
-```swift
-do {
-    let decryptedMessage = try contextImprint.unwrapData(encryptedMessage,
-                                                         context: context.data(using: .utf8)!)
-    print("decrypted message: ", String(data: decryptedMessage, encoding: .utf8)!)
-}
-catch let error as NSError {
-    print("failed to decrypt message: \(error)")
-    return
-}
-```
-
-### Secure Session
-
-Secure Session is a sequence- and session- dependent, stateful messaging system. It is suitable for protecting long-lived peer-to-peer message exchanges where the secure data exchange is tied to a specific session context.
-
-Secure Session operates in two stages:
-* **session negotiation** where the keys are established and cryptographic material is exchanged to generate ephemeral keys and
-* **data exchange** where exchanging of messages can be carried out between peers.
-
-You can read a more detailed description of the process [here](/pages/secure-session-cryptosystem/).
-
-Put simply, Secure Session takes the following form:
-
-- Both clients and server construct a Secure Session object, providing:
-    - an arbitrary identifier,
-    - a private key, and
-    - a callback function that enables it to acquire the public key of the peers with which they may establish communication.
-- A client will generate a "connect request" and by whatever means it will dispatch that to the server.
-- A server will enter a negotiation phase in response to a client's "connect request".
-- Clients and servers will exchange messages until a "connection" is established.
-- Once a connection is established, clients and servers may exchange secure messages according to whatever application level protocol was chosen.
-
-
-#### Secure Session Workflow
-
-Secure Session has two parties called "client" and "server" for the sake of simplicity, but they could be more precisely called "initiator" and "acceptor" — the only difference between them is in who starts the communication.
-
-Secure Session relies on the user's passing a number of callback functions to send/receive messages — and the keys are retrieved from local storage (see more in [Secure Session cryptosystem description](/pages/secure-session-cryptosystem/)).
-
-
-#### Initialise Secure Session
-
-Client ID can be obtained from the server or is generated by the client. You can play with [Themis Interactive Simulator (Themis Server)](/simulator/interactive/) to get the keys and simulate the whole client-server communication.
-
-```swift
-guard
-    let clientIdData = clientId.data(using: String.Encoding.utf8),
-    let clientPrivateKey = Data(base64Encoded: kClientPrivateKey)
+guard let decryptedMessage = try? cell.decrypt(encryptedMessage,
+                                               context: context)
 else {
-    print("failed to decode base64")
-    return
+    // handle decryption failure
 }
-
-var transport = Transport()
-transport.setupKeys(kServerId, serverPublicKey: kServerPublicKey)
-
-let session = TSSession(userId: clientIdData, privateKey: clientPrivateKey, callbacks: transport)
 ```
 
-#### Transport interface
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will return an error if those are incorrect or if the encrypted data was corrupted.
 
-Implement transport interface to return server's public key. Transport layer simply returns server public key for requests using server ID.
+### Token Protect mode
+
+[**Token Protect mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#token-protect-mode)
+should be used if you cannot allow the length of the encrypted data to grow
+but have additional storage available elsewhere for the authentication token.
+Other than that,
+Token Protect mode has the same security properties as the Seal mode.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
 ```swift
-final class Transport: TSSessionTransportInterface {
+let symmetricKey = TSGenerateSymmetricKey()!
 
-    fileprivate var serverId: String?
-    fileprivate var serverPublicKeyData: Data?
+let cell = TSCellToken(key: symmetricKey)!
+```
 
-    func setupKeys(_ serverId: String, serverPublicKey: String) {
-        self.serverId = serverId
-        self.serverPublicKeyData = Data(base64Encoded: serverPublicKey,
-                                        options: .ignoreUnknownCharacters)
-    }
+Now you can encrypt the data using the `encrypt` method:
 
-    override func publicKey(for binaryId: Data!) throws -> Data {
-        let error: Error = NSError(domain: "com.themisserver.example", code: -1, userInfo: nil)
-        let stringFromData = String(data: binaryId, encoding: String.Encoding.utf8)
-        if stringFromData == nil {
-            throw error
+```swift
+let plaintext: Data = ...
+let context: Data = ...
+
+let result = try! cell.encrypt(plaintext, context:context)
+let encrypted: Data = result.encrypted
+let authToken: Data = result.token
+```
+
+The _associated context_ argument is optional and can be omitted.
+
+Token Protect mode produces encrypted text and authentication token separately.
+Encrypted data has the same length as the input:
+
+```swift
+assert(encrypted.count == plaintext.count)
+```
+
+You need to save both the encrypted data and the token, they are necessary for decryption.
+Use the `decrypt` method for that:
+
+```swift
+guard let decryptedMessage = try? cell.decrypt(encryptedMessage,
+                                               token: authToken,
+                                               context: context)
+else {
+    // handle decryption failure
+}
+```
+
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+Secure Cell will return an error if those are incorrect
+or if the data or the authentication token was corrupted.
+
+### Context Imprint mode
+
+[**Context Imprint mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#context-imprint-mode)
+should be used if you absolutely cannot allow the length of the encrypted data to grow.
+This mode is a bit harder to use than the Seal and Token Protect modes.
+Context Imprint mode also provides slightly weaker integrity guarantees.
+
+<!-- See API reference here. -->
+
+Initialise a Secure Cell with a secret of your choice to start using it.
+Context Imprint mode supports only [symmetric keys](#symmetric-keys).
+
+```swift
+let symmetricKey = TSGenerateSymmetricKey()!
+
+let cell = TSCellContextImprint(key: symmetricKey)!
+```
+
+Now you can encrypt the data using the `encrypt` method:
+
+```swift
+let plaintext: Data = ...
+let context: Data = ...
+
+let encrypted: Data = try! cell.encrypt(plaintext, context: context)
+```
+
+{{< hint info >}}
+**Note:**
+Context Imprint mode **requires** associated context for encryption and decryption.
+For the highest level of security, use a different context for each data piece.
+{{< /hint >}}
+
+Context Imprint mode produces encrypted text of the same size as the input:
+
+```swift
+assert(encrypted.count == plaintext.count)
+```
+
+You can decrypt the data back using the `decrypt` method:
+
+```swift
+let decryptedMessage = try! cell.decrypt(encryptedMessage,
+                                         context: context)
+if looksCorrect(decryptedMessage) {
+    // process decrypted data
+}
+```
+
+{{< hint warning >}}
+**Warning:**
+In Context Imprint mode, Secure Cell cannot validate correctness of the decrypted data.
+If an incorrect secret or context is used, or if the data has been corrupted,
+Secure Cell will return garbage output without returning an error.
+{{< /hint >}}
+
+Make sure to initialise the Secure Cell with the same secret
+and provide the same associated context as used for encryption.
+You should also do some sanity checks after decryption.
+
+## Secure Message
+
+[**Secure Message**](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+is a lightweight container
+that can help deliver some message or data to your peer in a secure manner.
+It provides a sequence-independent, stateless, contextless messaging system.
+This may be preferred in cases that don't require frequent sequential message exchange
+and/or in low-bandwidth contexts.
+
+Secure Message is secure enough to exchange messages from time to time,
+but if you'd like to have [_perfect forward secrecy_](https://en.wikipedia.org/wiki/Forward_secrecy)
+and higher security guarantees,
+consider using [Secure Session](#secure-session) instead.
+
+Secure Message offers two modes of operation:
+
+  - In [**Sign–Verify mode**](#signature-mode),
+    the message is signed by the sender using their private key,
+    then it is verified by the recipient using the sender's public key.
+
+    The message is packed in a suitable container and signed with an appropriate algorithm,
+    based on the provided keypair type.
+    Note that the message is _not encrypted_ in this mode.
+
+  - In [**Encrypt–Decrypt mode**](#encryption-mode),
+    the message will be additionally encrypted
+    with an intermediate symmetric key using [Secure Cell](#secure-cell) in Seal mode.
+
+    The intermediate key is generated in such way that only the recipient can recover it.
+    The sender needs to provide their own private key
+    and the public key of the intended recipient.
+    Correspondingly, to get access to the message content,
+    the recipient will need to use their private key
+    along with the public key of the expected sender.
+
+Read more about
+[Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
+to understand better the underlying considerations, limitations, and features of each mode.
+
+### Signature mode
+
+[**Signature mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#signed-messages)
+only adds cryptographic signatures over the messages,
+enough for anyone to authenticate them and prevent tampering
+but without additional confidentiality guarantees.
+
+To begin, the sender needs to generate an [asymmetric keypair](#asymmetric-keypairs).
+The private key stays with the sender and the public key should be published.
+Any recipient with the public key will be able to verify messages
+signed by the sender which owns the corresponding private key.
+
+The **sender** initialises Secure Message using their private key:
+
+```swift
+let keypair = TSKeyGen(algorithm: .EC)!
+let privateKey = keypair.privateKey!
+let publicKey = keypair.publicKey!
+
+let secureMessage =
+    TSMessage(inSignVerifyModeWithPrivateKey: privateKey,
+                               peerPublicKey: nil)!
+```
+
+Messages can be signed using the `wrap` method:
+
+```swift
+let message: Data = ...
+
+let signedMessage: Data = try! secureMessage.wrap(message)
+```
+
+To verify messages, the **recipient** first has to obtain the sender's public key.
+Secure Message should be initialised using only the public key:
+
+```swift
+let peerPublicKey: Data = ...
+
+let secureMessage =
+    TSMessage(inSignVerifyModeWithPrivateKey: nil,
+                               peerPublicKey: peerPublicKey)!
+```
+
+Now the receipent may verify messages signed by the sender using the `unwrapData` method:
+
+```swift
+guard let verifiedMessage = try? secureMessage.unwrapData(signedMessage)
+else {
+    // handle verification error
+}
+```
+
+Secure Message will return an error if the message has been modified since the sender signed it,
+or if the message has been signed by someone else, not the expected sender.
+
+### Encryption mode
+
+[**Encryption mode**](/docs/themis/crypto-theory/crypto-systems/secure-message/#encrypted-messages)
+not only certifies the integrity and authenticity of the message,
+it also guarantees its confidentialty.
+That is, only the intended recipient is able to read the encrypted message,
+as well as to verify that it has been signed by the expected sender and arrived intact.
+
+For this mode, both the sender and the recipient—let's call them
+Alice and Bob—each need to generate an [asymmetric keypair](#symmetric-keypairs) of their own,
+and then send their public keys to the other party.
+
+{{< hint info >}}
+**Note:**
+Be sure to authenticate the public keys you receive to prevent Man-in-the-Middle attacks.
+You can find [key management guidelines here](/docs/themis/crypto-theory/key-management/).
+{{< /hint >}}
+
+**Alice** initialises Secure Message with her private key and Bob's public key:
+
+```swift
+let aliceKeypair = TSKeyGen(algorithm: .EC)!
+let alicePrivateKey = aliceKeypair.privateKey!
+let bobPublicKey: Data = ... // received securely
+
+let aliceSecureMessage =
+    TSMessage(inEncryptModeWithPrivateKey: alicePrivateKey,
+                            peerPublicKey: bobPublicKey)!
+```
+
+Now Alice can encrypt messages for Bob using the `wrap` method:
+
+```swift
+let message: Data = ...
+
+let encryptedMessage: Data = try! secureMessage.wrap(message)
+```
+
+**Bob** initialises Secure Message with his private key and Alice's public key:
+
+```swift
+let bobKeypair = TSKeyGen(algorithm: .EC)!
+let bobPrivateKey = bobKeypair.privateKey!
+let alicePublicKey: Data = ... // received securely
+
+let bobSecureMessage =
+    TSMessage(inEncryptModeWithPrivateKey: bobPrivateKey,
+                            peerPublicKey: alicePublicKey)!
+```
+
+With this, Bob is able to decrypt messages received from Alice
+using the `unwrapData` method:
+
+```swift
+guard let decryptedMessage = try? secureMessage.unwrapData(encryptedMessage)
+else {
+    // handle decryption error
+}
+```
+
+Bob's Secure Message will return an error
+if the message has been modified since Alice encrypted it;
+or if the message was encrypted by Carol, not by Alice;
+or if the message was actually encrypted by Alice but *for Carol* instead, not for Bob.
+
+## Secure Session
+
+[**Secure Session**](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+is a lightweight protocol for securing any kind of network communication,
+on both private and public networks, including the Internet.
+It operates on the 5th layer of the network OSI model (the session layer).
+
+Secure Session provides a stateful, sequence-dependent messaging system.
+This approach is suitable for protecting long-lived peer-to-peer message exchanges
+where the secure data exchange is tied to a specific session context.
+
+Communication over Secure Session consists of two stages:
+
+  - **Session negotiation** (key agreement),
+    during which the peers exchange their cryptographic material and authenticate each other.
+    After a successful mutual authentication,
+    each peer derives a session-shared secret and other auxiliary data
+    (session ID, sequence numbers, etc.)
+
+  - **Actual data exchange**,
+    when the peers securely exchange data provided by higher-layer application protocols.
+
+<!-- (Actually, it *does* support both, but the callback API is broken.)
+
+Secure Session supports two operation modes:
+
+  - [**Buffer-aware API**](#buffer-aware-api)
+    in which encrypted messages are handled explicitly, with data buffers you provide.
+  - [**Callback-oriented API**](#callback-oriented-api)
+    in which Secure Session handles buffer allocation implicitly
+    and uses callbacks to notify about incoming messages or request sending outgoing messages.
+ -->
+
+Read more about
+[Secure Session cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-session/)
+to understand better the underlying considerations,
+get an overview of the protocol and its features,
+etc.
+
+### Setting up Secure Session
+
+Secure Session has two parties called “client” and “server” for the sake of simplicity,
+but they could be more precisely called “initiator” and “acceptor” –
+the only difference between the two is in who starts the communication.
+After the session is established, either party can send messages to their peer whenever it wishes to.
+
+{{< hint info >}}
+Take a look at code samples in the [`docs/examples/swift`](https://github.com/cossacklabs/themis/tree/master/docs/examples/swift)
+and [`docs/examples/Themis-server/swift`](https://github.com/cossacklabs/themis/tree/master/docs/examples/Themis-server/swift)
+directories on GitHub.
+There you can find examples of Secure Session setup and usage in all modes.
+{{< /hint >}}
+
+First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
+and exchange their public keys.
+The private keys should never be shared with anyone else.
+
+Each party should also choose a unique *peer ID* –
+arbitrary byte sequence identifying their public key.
+Read more about peer IDs in [Secure Session cryptosystem overview](/docs/themis/crypto-theory/crypto-systems/secure-session/#peer-ids-and-keys).
+The peer IDs need to be exchanged along with the public keys.
+
+To identify peers, Secure Session uses a **callback interface**.
+It calls the `publicKey` method to locate a public key associated with presented peer ID.
+Typically, each peer keeps some sort of a database of known public keys
+and fulfills Secure Session requests from that database.
+
+```swift
+final class SessionCallbacks: TSSessionTransportInterface {
+    override func publicKey(for peerID: Data) throws -> Data? {
+        // Retrieve public key for "peerID" from the trusted storage.
+        if !found {
+            return nil
         }
-
-        if stringFromData == serverId {
-            guard let resultData: Data = serverPublicKeyData else {
-                throw error
-            }
-            return resultData
-        }
-
-        return Data()
+        return publicKey
     }
 }
 ```
 
-#### Connect Secure Session
+Each peer initialises Secure Session with their ID, their private key,
+and an instance of the callback interface:
 
 ```swift
-do {
-    guard let connectionMessage = try session!.connectRequest() else {
-        throw NSError(domain: "com.themisserver.example", code: -2, userInfo: nil)
+let peerID: Data = ...
+let privateKey: Data = ...
+let callbacks = SessionCallbacks(...)
+
+let session = TSSession(userId: peerID, privateKey: privateKey,
+                        callbacks: callbacks)!
+```
+
+{{< hint info >}}
+**Note:**
+The same callback interface may be shared by multiple Secure Session instances,
+provided it is correctly synchronised.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+<!-- (The interface exists, but it's currently unusable. And may be inaccurate.)
+
+#### Transport callbacks
+
+If you wish to use the **callback-oriented API** of Secure Session,
+you have to implement two additional methods of the callback interface:
+
+```swift
+final class SessionCallbacks: TSSessionTransportInterface {
+    override func send(_ data: Data) throws {
+        // Send "data" to the peer over the network.
+        // Throw an error if that fails.
     }
-    // send "connectionMessage" to server
-}
-catch let error {
-    print("failed to generate connection request: \(error)")
-    return
+
+    override func receiveDataWithError() throws -> Data {
+        // Receive a message for peer and return it.
+        // Throw an error if that fails.
+    }
+
+    override func publicKey(for peerID: Data) throws -> Data? {
+        // Implement this required method as well.
+    }
 }
 ```
 
-Client should send `connectionMessage`, get response, and check if `isSessionEstablished` before sending payload.
+{{< hint warning >}}
+**Warning:**
+In send–receive mode, each Secure Session needs its own instance of transport callback interface.
+The same instance cannot be shared by multiple sessions.
+Read more about [thread safety of Secure Session](/docs/themis/debugging/thread-safety/#shared-secure-session-transport-objects).
+{{< /hint >}}
+
+-->
+
+### Using Secure Session
+
+SwiftThemis supports only
+[**buffer-aware API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#buffer-aware-api)
+(aka *wrap–unwrap* mode).
+It is easy to integrate into existing applications with established network processing path.
+
+#### Establishing connection
+
+The client initiates the connection and sends the first request to the server:
 
 ```swift
-let data: Data = ... // received server response data after sending "connectionMessage"
+let negotiationMessage = try! session.connectRequest()
 
-do {
-    guard let decryptedMessage = try session!.unwrapData(data) else {
-        throw NSError(domain: "com.themisserver.example", code: -4, userInfo: nil)
+sendToPeer(negotiationMessage)
+```
+
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
+
+```swift
+while true {
+    let request: Data = receiveFromPeer()
+    let reply = try? session.unwrapData(request)
+    if session.isSessionEstablished() {
+        break
     }
-    if session!.isSessionEstablished() {
-        // session is established: break out of loop
-    } else {
-        // session is NOT established yet
-        // send "decryptedMessage" to the server
-    }
-}
-catch let error {
-    print("failed to negotiate: \(error)")
-    return
+    sendToPeer(reply!)
 }
 ```
 
-After the loop finishes, Secure Session is established and is ready to be used.
+#### Exchanging messages
 
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
 
-#### Send and receive data
+In buffer-aware API, the messages are wrapped into Secure Session protocol and sent separately:
 
 ```swift
-do {
-    guard let encryptedMessage = try session?.wrap(message.data(using: String.Encoding.utf8)) else {
-        throw NSError(domain: "com.themisserver.example", code: -5, userInfo: nil)
-    }
-    // send "encryptedMessage" to the server
-} catch let error {
-    print("failed to encrypt: \(error)")
-    return
-}
+let message: Data = ...
 
-// ...
+let encryptedMessage: Data = try! session.wrap(message)
 
-do {
-    guard let decryptedMessage = try session!.unwrapData(data) else {
-        throw NSError(domain: "com.themisserver.example", code: -6, userInfo: nil)
-    }
-    // "decryptedMessage" contains server response
-}
-catch let error {
-    print("failed to decrypt: \(error)")
-    return
+sendToPeer(encryptedMessage)
+```
+
+You can wrap multiple messages before sending them out.
+Encrypted messages are independent.
+
+{{< hint info >}}
+**Note:**
+Secure Session allows occasional message loss,
+slight degree of out-of-order delivery, and some duplication.
+However, it is still a sequence-dependent protocol.
+Do your best to avoid interrupting the message stream.
+{{< /hint >}}
+
+After receiving an encrypted message, you need to unwrap it:
+
+```swift
+let encryptedMessage: Data = receiveFromPeer()
+
+guard let decryptedMessage = try? session.unwrapData(encryptedMessage)
+else {
+    // handle corrupted messages
 }
 ```
 
-This is it. See the full example in [docs/examples/Themis-server/swift](https://github.com/cossacklabs/themis/tree/master/docs/examples/Themis-server/swift).
+Secure Session ensures message integrity and will return an error
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
 
-### Secure Comparator
+<!-- (The interface exists, but it's currently unusable. And may be incorrect.)
 
-Secure Comparator is an interactive protocol for two parties that compares whether they share the same secret or not. It is built around a [Zero Knowledge Proof](https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html)-based protocol ([Socialist Millionaire's Protocol](https://en.wikipedia.org/wiki/Socialist_millionaires)), with a number of [security enhancements](https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf).
+### Callback-oriented API
 
-Secure Comparator is transport-agnostic and only requires the user(s) to pass messages in a certain sequence. The protocol itself is ingrained into the functions and requires minimal integration efforts from the developer.
+[**Callback-oriented API**](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+(aka *send–receive* mode)
+uses Secure Session as a framework for network communication, handling data buffers implicitly.
+It allows for simpler messaging code at an expense of more complex setup code.
 
-#### Secure Comparator workflow
+{{< hint info >}}
+**Note:**
+Remember to [configure transport callbacks](#transport-callbacks) for Secure Session,
+they are required to use the callback-oriented API.
+{{< /hint >}}
 
-Secure Comparator has two parties — called "client" and "server" — the only difference between them is in who starts the comparison.
+#### Establishing connection
 
-#### Secure Comparator client
+The client initiates the connection and sends the first request to the server:
 
 ```swift
-let sharedMessage = "shared secret"
+try session.connect()
+```
 
-let client = TSComparator(messageToCompare: sharedMessage.data(using: .utf8)!)!
+Then both parties communicate to negotiate the keys and other details
+until the connection is established:
 
-var data = try? client.beginCompare()
-
-while (client.status() == TSComparatorStateType.comparatorNotReady) {
-    // send data to the server, receive response, and process it
-    self.sendDataOnServer(data)
-    data = self.receiveServerResponse()
-    data = try? client.proceedCompare(data)
+```swift
+while true {
+    NSError *error;
+    try session.unwrapAndReceive(4096)
+    if session.isSessionEstablished() {
+        break
+    }
 }
 ```
 
-After the loop finishes, the comparison is over and its result can be checked by calling `status`:
+Note that actual networking happens implicitly, within the Secure Session object
+which calls appropriate transport callbacks to send and receive data over the network.
+
+#### Exchanging messages
+
+After the session is established,
+the parties can proceed with actual message exchange.
+At this point the client and the server are equal peers –
+they can both send and receive messages independently, in a duplex manner.
+
+Send messages as if the Secure Session were a network socket,
+using the `wrapAndSend` method:
 
 ```swift
-if (client.status() == TSComparatorStateType.comparatorMatch) {
+let message: Data = ...
+
+try session.wrapAndSend(message)
+```
+
+Secure Session encrypts the message, wraps it into the protocol,
+and synchronously calls the `sendData` transport callback to ship the message out.
+Networking errors are reported by throwing appropriate exceptions.
+
+The receiving side uses the `unwrapAndReceive` method to receive messages:
+
+```swift
+let length = 4096 // max message length
+let message: Data = try session.unwrapAndReceive(length)
+```
+
+Secure Session synchronously calls the `receiveDataWithError` transport callback
+to wait for the next message, then unwraps and decrypts it,
+and returns already decrypted message to the application.
+
+Secure Session ensures message integrity and will return an error
+if the message has been modified in-flight.
+It will also detect and report protocol anomalies,
+such as unexpected messages, outdated messages, etc.
+
+-->
+
+## Secure Comparator
+
+[**Secure Comparator**](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+is an interactive protocol for two parties that compares whether they share the same secret or not.
+It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
+([Socialist Millionaire's Protocol][SMP]),
+with a number of [security enhancements][paper].
+
+[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
+[paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
+
+Secure Comparator is transport-agnostic.
+That is, the implementation handles all intricacies of the protocol,
+but the application has to supply networking capabilities to exchange the messages.
+
+Read more about
+[Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
+to understand better the underlying considerations,
+get an overview of the protocol, etc.
+
+### Comparing secrets
+
+Secure Comparator has two parties called “client” and “server” for the sake of simplicity,
+but the only difference between the two is in who initiates the comparison.
+
+Both parties start by initialising Secure Comparator with the secret they need to compare:
+
+```swift
+let sharedSecret: Data = ...
+
+let comparison = TSComparator(messageToCompare: sharedSecret)!
+```
+
+The client initiates the protocol and sends the message to the server:
+
+```swift
+let message = try! comparison.beginCompare()
+
+sendToPeer(message)
+```
+
+Now, each peer waits for a message from the other one,
+passes it to Secure Comparator, and gets a response that needs to be sent back.
+The comparison is complete when the response is empty:
+
+```swift
+while true {
+    let message: Data = receiveFromPeer()
+    guard let response = try? comparison.proceedCompare(message)
+    else {
+        // handle protocol error
+    }
+    if comparison.status() != TSComparatorStateType.comparatorNotReady {
+        // Comparison complete!
+        break
+    }
+    sendToPeer(response)
+}
+```
+
+Once the comparison is complete, you can get the results (on each side):
+
+```swift
+if client.status() == TSComparatorStateType.comparatorMatch {
     // secrets match
-    print("SecureComparator secrets match")
-} else {
-    // secrets don't match
-    print("SecureComparator secrets do not match")
 }
 ```
 
-#### Secure Comparator server
-
-The server part can be described in any language, but let's pretend here that both client and server are using Swift.
-
-```swift
-let sharedMessage = "shared secret"
-let server = TSComparator(messageToCompare: sharedMessage.data(using: .utf8)!)!
-
-var data: Data
-
-while (server.status() == TSComparatorStateType.comparatorNotReady) {
-    // receive from client, process, and send reply
-    data = self.receiveFromClient()
-    data = try? server.proceedCompare(data)
-    self.sendToClient(data)
-}
-```
-
-After the loop finishes, the comparison is over and its result can be checked by calling `status`:
-
-```swift
-if (server.status() == TSComparatorStateType.comparatorMatch) {
-    // secrets match
-    print("SecureComparator secrets match")
-} else {
-    // secrets don't match
-    print("SecureComparator secrets do not match")
-}
-```
+Secure Comparator performs consistency checks on the protocol messages
+and will return an error if they were corrupted.
+But if the other party fails to demonstrate that it has a matching secret,
+Secure Comparator will only return a negative result.

--- a/docs/themis/languages/wasm/features.md
+++ b/docs/themis/languages/wasm/features.md
@@ -319,8 +319,8 @@ You can decrypt the data back using the `decrypt` method:
 
 ```javascript
 let decrypted = cell.decrypt(encrypted, context)
-if (looksCorrect(decrypted)) {
-    // process decrypted data
+if (!correct(decrypted)) {
+    // handle decryption failure
 }
 ```
 

--- a/docs/themis/languages/wasm/features.md
+++ b/docs/themis/languages/wasm/features.md
@@ -582,6 +582,15 @@ WasmThemis supports only
 (aka *wrap–unwrap* mode).
 It is easy to integrate into existing applications with established network processing path.
 
+{{< hint info >}}
+**Note:**
+We consider buffer-aware API more fit for typical JavaScript applications,
+so currently Secure Session supports only this mode.
+However, if you find that [callback-oriented API](/docs/themis/crypto-theory/crypto-systems/secure-session/#callback-oriented-api)
+might be a good fit for your use case,
+[let us know](mailto:dev@cossacklabs.com).
+{{< /hint >}}
+
 #### Establishing connection
 
 The client initiates the connection and sends the first request to the server:

--- a/docs/themis/languages/wasm/features.md
+++ b/docs/themis/languages/wasm/features.md
@@ -155,13 +155,15 @@ Read more about
 [Secure Cell cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-cell/)
 to understand better the underlying considerations, limitations, and features of each mode.
 
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/wasm/latest/secure_cell/).
+-->
+
 ### Seal mode
 
 [**Seal mode**](/docs/themis/crypto-theory/crypto-systems/secure-cell/#seal-mode)
 is the most secure and easy to use mode of Secure Cell.
 This should be your default choice unless you need specific features of the other modes.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Seal mode supports [symmetric keys](#symmetric-keys) and passphrases.
@@ -223,8 +225,6 @@ but have additional storage available elsewhere for the authentication token.
 Other than that,
 Token Protect mode has the same security properties as the Seal mode.
 
-<!-- See API reference here. -->
-
 Initialise a Secure Cell with a secret of your choice to start using it.
 Token Protect mode supports only [symmetric keys](#symmetric-keys).
 
@@ -280,8 +280,6 @@ or if the data or the authentication token was corrupted.
 should be used if you absolutely cannot allow the length of the encrypted data to grow.
 This mode is a bit harder to use than the Seal and Token Protect modes.
 Context Imprint mode also provides slightly weaker integrity guarantees.
-
-<!-- See API reference here. -->
 
 Initialise a Secure Cell with a secret of your choice to start using it.
 Context Imprint mode supports only [symmetric keys](#symmetric-keys).
@@ -373,6 +371,10 @@ Secure Message offers two modes of operation:
 Read more about
 [Secure Message cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-message/)
 to understand better the underlying considerations, limitations, and features of each mode.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/wasm/latest/secure_message/).
+-->
 
 ### Signature mode
 
@@ -521,6 +523,10 @@ Read more about
 to understand better the underlying considerations,
 get an overview of the protocol and its features,
 etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/wasm/latest/secure_session/).
+-->
 
 ### Setting up Secure Session
 
@@ -679,6 +685,10 @@ Read more about
 [Secure Comparator cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-comparator/)
 to understand better the underlying considerations,
 get an overview of the protocol, etc.
+
+<!-- TODO: uncomment this when API docs are hosted there (T1682)
+See [full API reference here](/docs/themis/api/wasm/latest/secure_comparator/).
+-->
 
 ### Comparing secrets
 

--- a/docs/themis/languages/wasm/features.md
+++ b/docs/themis/languages/wasm/features.md
@@ -722,7 +722,7 @@ Once the comparison is complete, you can get the results (on each side):
 
 ```javascript
 if (comparison.compareEqual()) {
-    // secret equal
+    // shared secrets match
 }
 ```
 

--- a/docs/themis/languages/wasm/features.md
+++ b/docs/themis/languages/wasm/features.md
@@ -516,14 +516,6 @@ Communication over Secure Session consists of two stages:
   - **Actual data exchange**,
     when the peers securely exchange data provided by higher-layer application protocols.
 
-Secure Session supports two operation modes:
-
-  - [**Buffer-aware API**](#buffer-aware-api)
-    in which encrypted messages are handled explicitly, with data buffers you provide.
-  - [**Callback-oriented API**](#callback-oriented-api)
-    in which Secure Session handles buffer allocation implicitly
-    and uses callbacks to notify about incoming messages or request sending outgoing messages.
-
 Read more about
 [Secure Session cryptosystem design](/docs/themis/crypto-theory/crypto-systems/secure-session/)
 to understand better the underlying considerations,


### PR DESCRIPTION
Add feature guides for the rest of the languages, following #5.

All the guides have the same structure laid out earlier, with some specifics.

- ObjCThemis/SwiftThemis have callback API for Secure Session, but closer inspection has uncovered that it's broken. Documentation for this API has been updated _and_ hidden for now.
- PHPThemis does not have Secure Comparator yet. There is a placeholder for that.
- PyThemis and RbThemis have a different API for Secure Message that other languages
- RustThemis supports only EC keys for Secure Session.

Also, make some consistency improvements:

- Note those languages that do not have callback API of Secure Session, like the old docs do for Ruby.
- Miscellaneous minor tweaks.

And also, add links to API docs where available (Go, Rust, Ruby) and placeholders for other languages.