### PR TITLE
Fix broken links

### DIFF
--- a/themis/community/contributing.md
+++ b/themis/community/contributing.md
@@ -41,11 +41,11 @@ If you'd like to participate in the core development more closely,
 
 ### Getting ready
 
- 1. Read the [Themis architecture](/themis/themis-architecture/) section of the documentation,
+ 1. Read the [Themis architecture](/themis/architecture/) section of the documentation,
     make sure that you understand everything
     (or at least you start thinking you understand everything).
 
- 2. Get familiar with the [directory structure](/themis/themis-architecture/directory-structure/)
+ 2. Get familiar with the [directory structure](/themis/architecture/directory-structure/)
     and the way the [build system](/themis/installation/installation-from-sources/) works.
 
  3. Brace yourself for a lengthy session of reading the source code.

--- a/themis/community/credits.md
+++ b/themis/community/credits.md
@@ -6,7 +6,7 @@ title:  Credits and honours
 # Credits and honourable mentions
 
 Significant contributions to Themis encryption library have been made
-by Ignat Korchagin ([@secumod](https://github.com/secumod))
+by Ignat Korchagin ([@ignatk](https://github.com/ignatk))
 and Andrey Mnazakanov ([@mnaza](https://www.github.com/mnaza)).
 
 As for 2020, Themis is supported by core crew:
@@ -45,7 +45,7 @@ A special thank you goes to the awesome contributors that help us make Themis be
   a possible null pointer deference caused by the misusage of short-circuit evaluation
   ([#314](https://github.com/cossacklabs/themis/pull/314)).
 - [@valeriyvan](https://github.com/valeriyvan) for numerous improvements in iOS support and examples.
-- [@bryongloden](https://github.com/bryongloden) for numerous changes and suggestions.
+- [@bryongloden](https://github.com/bryonglodencissp) for numerous changes and suggestions.
 - [@outspace](https://github.com/outspace) for spotting code imperfections like a hawk,
   when even the mighty Valgrind failed to do so
   ([#514](https://github.com/cossacklabs/themis/issues/514),

--- a/themis/installation/installation-from-sources.md
+++ b/themis/installation/installation-from-sources.md
@@ -204,7 +204,7 @@ Note that **both** `libcrypto.a` and `libdecrepit.a` have to be put into `ENGINE
 #### Selecting algorithm parameters
 
 Themis is designed to be algorithm-agnostic thanks to its special abstraction layer,
-[Soter](/themis/themis-architecture/).
+[Soter](/themis/architecture/).
 It could be built with custom ciphers or cipher implementations
 specific to your regulatory needs or available in your environment.
 
@@ -253,20 +253,20 @@ For iOS, Android, and WebAssembly you do not need to build Themis Core separatel
 
 ### Server-side and desktop platforms
 
-  - [C++](/themis/languages/cpp/installation#building-latest-version-from-source)
-  - [Go](/themis/languages/go/installation#building-latest-version-from-source)
-  - [JavaScript (Node.js)](/themis/languages/nodejs/installation#building-latest-version-from-source)
-  - [Java](/themis/languages/java/installation-desktop#building-latest-version-from-source)
-  - [Kotlin](/themis/languages/kotlin/installation-desktop#building-latest-version-from-source)
-  - [PHP](/themis/languages/php/installation#building-latest-version-from-source)
-  - [Python](/themis/languages/python/installation#building-latest-version-from-source)
-  - [Ruby](/themis/languages/ruby/installation#building-latest-version-from-source)
-  - [Rust](/themis/languages/rust/installation#building-latest-version-from-source)
+  - [C++](/themis/languages/cpp/installation/#building-latest-version-from-source)
+  - [Go](/themis/languages/go/installation/#building-latest-version-from-source)
+  - [JavaScript (Node.js)](/themis/languages/nodejs/installation/#building-latest-version-from-source)
+  - [Java](/themis/languages/java/installation-desktop/#building-latest-version-from-source)
+  - [Kotlin](/themis/languages/kotlin/installation-desktop/#building-latest-version-from-source)
+  - [PHP](/themis/languages/php/installation/#building-latest-version-from-source)
+  - [Python](/themis/languages/python/installation/#building-latest-version-from-source)
+  - [Ruby](/themis/languages/ruby/installation/#building-latest-version-from-source)
+  - [Rust](/themis/languages/rust/installation/#building-latest-version-from-source)
 
 ### Mobile and Web platforms
 
-  - [Swift](/themis/languages/swift/installation#building-latest-version-from-source)
-  - [Objective-C](/themis/languages/objc/installation#building-latest-version-from-source)
-  - [Kotlin](/themis/languages/kotlin/installation-android#building-latest-version-from-source)
-  - [Java](/themis/languages/java/installation-android#building-latest-version-from-source)
-  - [JavaScript (WebAssembly)](/themis/languages/wasm/installation#building-latest-version-from-source)
+  - [Swift](/themis/languages/swift/installation/#building-latest-version-from-source)
+  - [Objective-C](/themis/languages/objc/installation/#building-latest-version-from-source)
+  - [Kotlin](/themis/languages/kotlin/installation-android/#building-latest-version-from-source)
+  - [Java](/themis/languages/java/installation-android/#building-latest-version-from-source)
+  - [JavaScript (WebAssembly)](/themis/languages/wasm/installation/#building-latest-version-from-source)


### PR DESCRIPTION
@ColliderBang has found several broken links, let's fix them.

"Themis Architecture" section has been renamed to avoid stuttering but apparently not all links have been fixed up. Use correct ones.

Links to installation pages with anchors should have slashes after all, but they should come *before* the anchors.

Ignat is now knows as @ignatk, the old @secumod nickname is not used anymore. Similarly, Bryon has a slightly different GitHub handle.