### PR TITLE
Document key kind restrictions for Secure Session

### DIFF
--- a/themis/crypto-theory/cryptosystems/secure-session.md
+++ b/themis/crypto-theory/cryptosystems/secure-session.md
@@ -167,19 +167,14 @@ The only requirement for peer ID is that it cannot be empty
 and it must uniquely identify the public key used by a peer.
 
 **Keypairs** can be securely generated with Themis key generation functions.
-Secure Session supports both EC and RSA key pairs.
+Secure Session only supports EC keys. RSA support is available per request only.
+Please [contact us](mailto:dev@cossacklabs.com) if you need to use RSA or other key types.
 
 The API is described in
 [`src/themis/secure_keygen.h`](https://github.com/cossacklabs/themis/blob/master/src/themis/secure_keygen.h):
 
 ```c
 themis_status_t themis_gen_ec_key_pair(
-    uint8_t* private_key,
-    size_t*  private_key_length,
-    uint8_t* public_key,
-    size_t*  public_key_length);
-
-themis_status_t themis_gen_rsa_key_pair(
     uint8_t* private_key,
     size_t*  private_key_length,
     uint8_t* public_key,

--- a/themis/languages/cpp/features.md
+++ b/themis/languages/cpp/features.md
@@ -571,6 +571,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/go/features.md
+++ b/themis/languages/go/features.md
@@ -558,6 +558,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/java/features.md
+++ b/themis/languages/java/features.md
@@ -571,6 +571,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/kotlin/features.md
+++ b/themis/languages/kotlin/features.md
@@ -558,6 +558,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/nodejs/features.md
+++ b/themis/languages/nodejs/features.md
@@ -535,6 +535,10 @@ There you can find examples of Secure Session setup and usage.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/objc/features.md
+++ b/themis/languages/objc/features.md
@@ -549,6 +549,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/php/features.md
+++ b/themis/languages/php/features.md
@@ -488,6 +488,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/python/features.md
+++ b/themis/languages/python/features.md
@@ -540,6 +540,10 @@ There you can find examples of Secure Session setup and usage.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/ruby/features.md
+++ b/themis/languages/ruby/features.md
@@ -499,6 +499,10 @@ There you can find examples of Secure Session setup and usage.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/rust/features.md
+++ b/themis/languages/rust/features.md
@@ -554,6 +554,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 {{< hint warning >}}
 **Note:**

--- a/themis/languages/swift/features.md
+++ b/themis/languages/swift/features.md
@@ -534,6 +534,10 @@ There you can find examples of Secure Session setup and usage in all modes.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.

--- a/themis/languages/wasm/features.md
+++ b/themis/languages/wasm/features.md
@@ -551,6 +551,10 @@ There you can find examples of Secure Session setup and usage.
 First, both parties have to generate [asymmetric keypairs](#asymmetric-keypairs)
 and exchange their public keys.
 The private keys should never be shared with anyone else.
+{{< hint info >}}
+**Note:**
+Secure Session only supports EC keys. RSA support is available per request only.
+{{< /hint >}}
 
 Each party should also choose a unique *peer ID* –
 arbitrary byte sequence identifying their public key.


### PR DESCRIPTION
As Secure Session API allows passing any type of key pair, but only works with EC keys, it's better to mention that fact in docs and language guides.