### PR TITLE
Update installation and import instructions for ObjC and Swift

### DIFF
--- a/themis/languages/objc/features.md
+++ b/themis/languages/objc/features.md
@@ -13,7 +13,7 @@ it is ready to use in your application!
 In order to use ObjCThemis, you need to import its headers:
 
 ```objc
-#import <objcthemis/objcthemis.h>
+@import themis;
 ```
 
 ---

--- a/themis/languages/objc/features.md
+++ b/themis/languages/objc/features.md
@@ -10,7 +10,7 @@ it is ready to use in your application!
 
 ## Using Themis
 
-In order to use ObjCThemis, you need to import its headers:
+In order to use ObjCThemis, you need to import it:
 
 ```objc
 @import themis;

--- a/themis/languages/objc/installation.md
+++ b/themis/languages/objc/installation.md
@@ -64,22 +64,12 @@ Themis is also available via [**Carthage**](https://github.com/Carthage/Carthage
     carthage update
     ```
 
- 3. Integrate **objcthemis.framework** into your project
+ 3. Integrate **themis.framework** into your project
     according to [Carthage instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
-    <!-- TODO: remove this with Themis 0.14 -->
     {{< hint warning >}}
 **Important:**
-"objcthemis.framework" is the new name of the framework, starting from Themis 0.13.
-You should integrate *this* framework into your applications.
-
-Currently, for Themis 0.13,
-Carthage will build both new "objcthemis.framework" and old "themis.framework"
-to allow existing users to migrate.
-Do not use "themis.framework" in new applications
-and update existing applications to use "objcthemis.framework" instead.
-
-The old "themis.framework" is scheduled to be **removed** in Themis 0.14.
+You should integrate *themis.framework* into your applications.
     {{< /hint >}}
 
 [Here are examples](../examples/) of Carthage projects with Themis in Swift and Objective-C.

--- a/themis/languages/objc/installation.md
+++ b/themis/languages/objc/installation.md
@@ -69,7 +69,7 @@ Themis is also available via [**Carthage**](https://github.com/Carthage/Carthage
 
     {{< hint warning >}}
 **Important:**
-You should integrate *themis.framework* into your applications.
+You should integrate only *themis.framework* into your applications. Do not integrate *openssl.framework* manually, as it is statically linked with Themis (Carthage handles linking.).
     {{< /hint >}}
 
 [Here are examples](../examples/) of Carthage projects with Themis in Swift and Objective-C.


### PR DESCRIPTION
Since Themis 0.13.2 release, we've switched back to use `themis.framework` instead of `objcthemis.framework`. Update Carthage installation instructions and ObjC usage instructions accordingly.