### PR TITLE
Spell "keystore" as a single word

### DIFF
--- a/acra/keys/_index.md
+++ b/acra/keys/_index.md
@@ -11,14 +11,14 @@ Acra uses a multitude of keys for different purposes:
   - transport keys for encrypting communications
   - various auxiliary keys used by other features
 
-The keys are securely stored in a [**key store**](versions/)
+The keys are securely stored in a [**keystore**](versions/)
 which is located either on the server's filesystem,
 or in a remote location such as key management service (KMS) or hardware security module (HSM).
 Glance through the [inventory of Acra keys](inventory/) to learn
-what keys there are in the key store, where they are located, and how they are used.
+what keys there are in the keystore, where they are located, and how they are used.
 
 However, just storing the keys securely is not enough.
-It is crucial to manage the keys and operate the key store in a secure way as well.
+It is crucial to manage the keys and operate the keystore in a secure way as well.
 These are typical operations that you will need to perform:
 
   - [Generate keys](operations/generation/) when deploying a new Acra instance.

--- a/acra/keys/inventory.md
+++ b/acra/keys/inventory.md
@@ -43,7 +43,7 @@ Storage keys can be represented by either:
 
 ## Acra components
 
-Each Acra component needs to have its own key store (located in the `.acrakeys` directory by default)
+Each Acra component needs to have its own keystore (located in the `.acrakeys` directory by default)
 which contains a set of keys necessary for correct operation of the component.
 
 Here is an overview of core Acra keys and their locations:
@@ -64,7 +64,7 @@ Here is an overview of core Acra keys and their locations:
   - Other party transport public key.
 
     You should put the transport public key of AcraServer or AcraTranslator
-    into AcraConnector’s key store, depending on the connection type.
+    into AcraConnector’s keystore, depending on the connection type.
 
 **AcraServer** works with the following keys:
 

--- a/acra/keys/operations/_index.md
+++ b/acra/keys/operations/_index.md
@@ -1,12 +1,12 @@
 ---
 weight: 3
-title: Operating Acra key store
+title: Operating Acra keystore
 bookCollapseSection: true
 ---
 
-# Operating Acra key store
+# Operating Acra keystore
 
-Here are typical operations that you will need to perform when managing a key store:
+Here are typical operations that you will need to perform when managing a keystore:
 
   - [Generate keys](generation/) when deploying a new Acra instance.
   - [Back up keys](backup/) to prevent accidental data loss.

--- a/acra/keys/operations/backup.md
+++ b/acra/keys/operations/backup.md
@@ -4,35 +4,35 @@ title: Backing up keys
 bookCollapseSection: true
 ---
 
-# Key store backups
+# Keystore backups
 
-It is important to keep backup copies of Acra key store because
+It is important to keep backup copies of Acra keystore because
 this is one thing that if lost can make your data completely inaccessible to anyone.
-Key store contents are also *very* sensitive because if leaked,
+Keystore contents are also *very* sensitive because if leaked,
 your data may become completely *accessible* to anyone.
 
-Therefore it is crucial to make and store backups of the key store in a secure manner.
+Therefore it is crucial to make and store backups of the keystore in a secure manner.
 Acra has a number of tools to help you with this task.
 
 ## Backing up the master keys
 
-Acra keys are always stored encrypted in a key store, or in a backup of a key store.
-The keys are ultimately secured by a **master key** which opens the key store.
-A key store cannot be accessed without the corresponding master key.
-The master key is not a part of a key store and cannot be restored if lost.
+Acra keys are always stored encrypted in a keystore, or in a backup of a keystore.
+The keys are ultimately secured by a **master key** which opens the keystore.
+A keystore cannot be accessed without the corresponding master key.
+The master key is not a part of a keystore and cannot be restored if lost.
 Losing the master key means losing access to the encryption keys and all data encrypted with them.
 
 Keep a backup copy of the master keys safe.
 For example, you may consider keeping a printed paper copy in a physical safe secured to your building.
 
-## Backing up key store version 1
+## Backing up keystore version 1
 
 {{< hint info >}}
 **Note:**
 The `acra-backup` utility is available only in [Acra Enterprise Edition](https://www.cossacklabs.com/acra/#pricing).
 {{< /hint >}}
 
-To make a backup copy of a key store version 1,
+To make a backup copy of a keystore version 1,
 use `acra-backup` command for `export`:
 
 ```shell
@@ -42,7 +42,7 @@ acra-backup --action=export --file "encrypted-keys.dat"
 {{< hint info >}}
 **Note:**
 You need to have `ACRA_MASTER_KEY` environment varible set up
-to access the source key store for export.
+to access the source keystore for export.
 {{< /hint >}}
 
 This command will export all keys in the keystore,
@@ -64,9 +64,9 @@ The key is shown to you just once, take a note of it.
 Store the encrypted backup and the key used to decrypt it separately.
 {{< /hint >}}
 
-To restore a key store from a backup copy,
+To restore a keystore from a backup copy,
 use `acra-backup` command for `import`.
-You need to set the `ACRA_MASTER_KEY` environment variable for the new key store,
+You need to set the `ACRA_MASTER_KEY` environment variable for the new keystore,
 as well as set the backup master key in the `BACKUP_MASTER_KEY` variable.
 
 ```shell
@@ -74,9 +74,9 @@ export BACKUP_MASTER_KEY=/74AXd3r9dfUDBp2Te+5CQArChnE2k5eM0CKIJ1HdoU=
 acra-backup --action=import --file "encrypted-keys.dat"
 ```
 
-## Backing up key store version 2
+## Backing up keystore version 2
 
-To make a backup copy of a key store version 2,
+To make a backup copy of a keystore version 2,
 use `acra-keys export` command with `--all` and `--private_keys` options:
 
 ```shell
@@ -88,7 +88,7 @@ acra-keys export --all --private_keys \
 {{< hint info >}}
 **Note:**
 You need to have `ACRA_MASTER_KEY` environment varible set up
-to access the source key store for export.
+to access the source keystore for export.
 {{< /hint >}}
 
 This command will export all keys in the keystore,
@@ -102,9 +102,9 @@ which are placed into the `access-keys.json` file.
 Store the encrypted backup and the keys used to decrypt it separately.
 {{< /hint >}}
 
-To restore a key store from a backup copy, start with an empty key store
+To restore a keystore from a backup copy, start with an empty keystore
 then import the backup with `acra-keys import`.
-You need to set the `ACRA_MASTER_KEY` environment variable for the new key store.
+You need to set the `ACRA_MASTER_KEY` environment variable for the new keystore.
 
 ```shell
 acra-keys import \
@@ -113,9 +113,9 @@ acra-keys import \
 ```
 
 <!--
-TODO: How do I make an empty key store?
+TODO: How do I make an empty keystore?
 It does not seem to be possible at the moment. Well, other than
     mkdir .acrakeys
-    echo -n "Acra Key Store v2" > .acrakeys/version
+    echo -n "Acra Keystore v2" > .acrakeys/version
 If ".acrakeys" is missing, just doing "acra-keys import" fails.
 -->

--- a/acra/keys/operations/destruction.md
+++ b/acra/keys/operations/destruction.md
@@ -42,8 +42,8 @@ For example, to remove old storage encryption keys:
 
 {{< hint info >}}
 **Note:**
-The above instructions work only for current key store version 1.
-New key store version 2 does not support key destruction at the moment.
+The above instructions work only for current keystore version 1.
+New keystore version 2 does not support key destruction at the moment.
 {{< /hint >}}
 
 <!--

--- a/acra/keys/operations/generation.md
+++ b/acra/keys/operations/generation.md
@@ -26,12 +26,12 @@ Due to security reasons,
 AcraServer, AcraTranslator, and AcraConnector all need to have *different* master keys.
 {{< /hint >}}
 
-Current key store version 1 uses one master key called `ACRA_MASTER_KEY`.
+Current keystore version 1 uses one master key called `ACRA_MASTER_KEY`.
 It is used only to encrypt the stored private keys.
 
-New key store version 2 uses two distinct master keys:
+New keystore version 2 uses two distinct master keys:
 one is used to encrypt private key material,
-the other one is used to sign public key store data.
+the other one is used to sign public keystore data.
 Both of them are still encoded as a single `ACRA_MASTER_KEY` value.
 
 ## 1. Setting up AcraServer
@@ -53,7 +53,7 @@ acra-keymaker --keystore=v1 --generate_master_key=master.key
 export ACRA_MASTER_KEY=$(cat master.key | base64)
 ```
 
-With key store version 2 you will need to use `acra-keymaker --keystore=v2`.
+With keystore version 2 you will need to use `acra-keymaker --keystore=v2`.
 
 {{< hint info >}}
 **Note:**
@@ -103,7 +103,7 @@ Stored keys should not be world-readable.
 AcraServer and AcraTranslator check this and will refuse to launch if access to the keys is not properly restricted.
 {{< /hint >}}
 
-If you are running Acra 0.86+ and wish to try the new [key store version 2](../versions/),
+If you are running Acra 0.86+ and wish to try the new [keystore version 2](../versions/),
 use `--keystore=v2` option when generating the keys:
 
 ```shell
@@ -140,7 +140,7 @@ acra-keymaker --keystore=v1 --generate_master_key=master.key
 export ACRA_MASTER_KEY=$(cat master.key | base64)
 ```
 
-(Or with `--keystore=v2` to set up for key store version 2.)
+(Or with `--keystore=v2` to set up for keystore version 2.)
 
 {{< hint info >}}
 **Note:**
@@ -178,7 +178,7 @@ Stored keys should not be world-readable.
 AcraConnector checks this and will refuse to launch if access to the keys is not properly restricted.
 {{< /hint >}}
 
-If you are running Acra 0.86+ and wish to try the new [key store version 2](../versions/),
+If you are running Acra 0.86+ and wish to try the new [keystore version 2](../versions/),
 use `--keystore=v2` option when generating the keys:
 
 ```shell
@@ -211,17 +211,17 @@ The rules of key exchange are simple:
 ### Exporting and importing keys
 
 <!--
-TODO: How about teaching "acra-keys import" and "acra-keys export" to work with key store v1?
+TODO: How about teaching "acra-keys import" and "acra-keys export" to work with keystore v1?
 That way you will need to explain this only once.
 -->
 
-Key exchange process is a bit different for current key store version 1 and the new version 2.
+Key exchange process is a bit different for current keystore version 1 and the new version 2.
 
-With key store version 1 you simply copy a file with `*.pub` extension from `.acrakeys` directory.
+With keystore version 1 you simply copy a file with `*.pub` extension from `.acrakeys` directory.
 For example, `.acrakeys/Alice_server.pub` is a public key of the client `Alice` on AcraServer,
 this file needs to be copied to corresponding `.acrakeys` directory of AcraConnector.
 
-Key store version 2 makes this process more secure
+Keystore version 2 makes this process more secure
 by ensuring that the key file cannot be tampered while en route between the server.
 First, the public key has to be _exported_ from AcraServer:
 
@@ -232,7 +232,7 @@ acra-keys export --key_bundle_file "encrypted-keys.dat" \
 ```
 
 then `encrypted-keys.dat` and `access-keys.json` files should be transferred by separate channels to AcraConnector
-where they are combined to import the key into the key store:
+where they are combined to import the key into the keystore:
 
 ```shell
 acra-keys import --key_bundle_file "encrypted-keys.dat" \
@@ -241,7 +241,7 @@ acra-keys import --key_bundle_file "encrypted-keys.dat" \
 
 {{< hint warning >}}
 **Note:**
-It is not possible to transfer keys of key store version 2 by simple copying.
+It is not possible to transfer keys of keystore version 2 by simple copying.
 The public key data is signed with a different key and will not be accepted.
 {{< /hint >}}
 
@@ -256,7 +256,7 @@ Place public key of AcraServer on AcraConnector and place public key of AcraConn
 | AcraServer    | transport public key of AcraConnector  | `.acrakeys/Alice.pub` |
 | AcraServer    | transport private key of AcraServer    | `.acrakeys/Alice_server` |
 
-With key store version 2 you need to export the following keys:
+With keystore version 2 you need to export the following keys:
 
 ```shell
 # On AcraServer
@@ -289,7 +289,7 @@ Place public key of AcraTranslator on AcraConnector and public key of AcraConnec
 | AcraTranslator | transport public key of AcraConnector   | `.acrakeys/Alice.pub` |
 | AcraTranslator | transport private key of AcraTranslator | `.acrakeys/Alice_translator` |
 
-With key store version 2 you need to export the following keys:
+With keystore version 2 you need to export the following keys:
 
 ```shell
 # On AcraTranslator
@@ -321,7 +321,7 @@ Place public key of AcraServer or AcraTranslator to AcraWriter.
 | AcraServer     | storage private key | `.acrakeys/Alice_storage` |
 | AcraTranslator | storage private key | `.acrakeys/Alice_storage` |
 
-With key store version 2 you need to export the following keys:
+With keystore version 2 you need to export the following keys:
 
 ```shell
 # On AcraServer or AcraTranslator
@@ -359,7 +359,7 @@ This creates a new zone and you get a JSON object like this:
 AcraWriter will need both the zone ID (returned as is) and the public key (returned in base64)
 to generate AcraStructs for the new zone.
 
-Zone keys are placed into the key store too:
+Zone keys are placed into the keystore too:
 
 | Component | should contain key | named like this |
 | --------- | ------------------ | --------------- |
@@ -367,7 +367,7 @@ Zone keys are placed into the key store too:
 | AcraServer     | zone private key | `.acrakeys/DDDDDDDDQHpbUSOgYTzqCktp_zone` |
 | AcraTranslator | zone private key | `.acrakeys/DDDDDDDDQHpbUSOgYTzqCktp_zone` |
 
-With key store version 2 you can import and export zone keys too:
+With keystore version 2 you can import and export zone keys too:
 
 ```shell
 # On AcraServer or AcraTranslator

--- a/acra/keys/operations/rotation.md
+++ b/acra/keys/operations/rotation.md
@@ -34,7 +34,7 @@ it is wise to rotate potentially affected keys immediately
 and be ready to do it again after the breach has been confirmed and contained.
 
 <!--
-Key store version 2 is able to track cryptoperiods of keys.
+Keystore version 2 is able to track cryptoperiods of keys.
 However, it is not possible to view them at the moment.
 This section will be expanded when that's available.
 -->
@@ -71,7 +71,7 @@ Acra keeps [a multitude of keys](../../inventory/) which require different appro
     Depending on your key rotation strategy,
     you might need to re-encrypt data with new data storage key.
 
-  - **Acra master keys** protect other keys in the key store.
+  - **Acra master keys** protect other keys in the keystore.
     Each Acra component has its own set of master keys which can be rotated independently.
     Currently, there's no easy way to rotate Master keys.
 

--- a/acra/keys/versions/_index.md
+++ b/acra/keys/versions/_index.md
@@ -1,13 +1,13 @@
 ---
 weight: 2
-title: Key store versions
+title: Keystore versions
 bookCollapseSection: true
 ---
 
-# Key store versions
+# Keystore versions
 
 We keep improving key storage and management in Acra.
-Starting from version 0.86, all Acra components support a new storage format: key store version 2.
+Starting from version 0.86, all Acra components support a new storage format: keystore version 2.
 New features include:
 
   - Stronger key integrity validation, preventing even more tampering attempts.
@@ -18,36 +18,36 @@ New features include:
   - Support for more external KMS types
     (only in [Acra Enterprise Edition](https://www.cossacklabs.com/acra/#pricing)).
 
-Key store version 1 is the current version, used by new Acra instances by default.
+Keystore version 1 is the current version, used by new Acra instances by default.
 You can *opt in* the new version 2 when [generating keys](../operations/generation/)
 by using the `--keystore=v2` option.
-Acra components can automatically tell which key store version is currently in use,
+Acra components can automatically tell which keystore version is currently in use,
 so special attention is necessary only during the initial key generation and exchange.
 
 {{< hint warning >}}
 **Note:**
-Key store version 2 is currently in development.
+Keystore version 2 is currently in development.
 Some features provided by version 1 may not be available yet for version 2.
 Please [let us know](mailto:dev@cossacklabs.com) if you run into any issues.
 {{< /hint >}}
 
 Of course it is also possible to convert existing key folders into the new format.
-See how to migrate existing Acra deployments [from key store v1 to v2](migrate-v1-to-v2/).
+See how to migrate existing Acra deployments [from keystore v1 to v2](migrate-v1-to-v2/).
 
-Key store version affects mostly the storage format and available key management options.
+Keystore version affects mostly the storage format and available key management options.
 The content of the keys – key material – stays the same.
-This means that different Acra components can run with different key store versions.
+This means that different Acra components can run with different keystore versions.
 For example, AcraServer may use improved version 2 while AcraConnector is still using version 1.
 
-## Key store version 1
+## Keystore version 1
 
-File-based key store version 1 uses a mostly flat file structure.
+File-based keystore version 1 uses a mostly flat file structure.
 Purposes of the keys are encoded in their file names.
 Private keys are stored encrypted.
 Public keys are stored in plain, they have a `*.pub` file name extension.
 Rotated keys are stored in directories with an `*.old` extension.
 
-For example, here is how a key store version 1 might look like:
+For example, here is how a keystore version 1 might look like:
 
 ```
 .acrakeys
@@ -71,18 +71,18 @@ For example, here is how a key store version 1 might look like:
 └── DDDDDDDDIgRssUkVnxCyGcDv_zone.pub
 ```
 
-## Key store version 2
+## Keystore version 2
 
-File-based key store version 2 uses a hierarchical file structure.
+File-based keystore version 2 uses a hierarchical file structure.
 Purposes of the keys are encoded in their file paths.
 Private keys are stored encrypted, public keys are stored in plain,
 both together inside a `*.keyring` file along with key metadata.
 Rotated keys are stored in the same `*.keyring` file too.
 
-The distinguishing feature of key store version 2 is the `version` file
-with the following string it in: `Acra Key Store v2`.
+The distinguishing feature of keystore version 2 is the `version` file
+with the following string it in: `Acra Keystore v2`.
 
-For example, here is how a key store version 2 might look like:
+For example, here is how a keystore version 2 might look like:
 
 ```
 .acrakeys

--- a/acra/keys/versions/migrate-v1-to-v2.md
+++ b/acra/keys/versions/migrate-v1-to-v2.md
@@ -1,12 +1,12 @@
 ---
 weight: 1
-title: Migration from key store v1 to v2
+title: Migration from keystore v1 to v2
 bookCollapseSection: true
 ---
 
-# Migration from key store v1 to v2
+# Migration from keystore v1 to v2
 
-In order to migrate from key store version 1 to version 2,
+In order to migrate from keystore version 1 to version 2,
 use `acra-keys` utility.
 
 ```shell
@@ -15,19 +15,19 @@ acra-keys migrate \
     --dst_keystore=v2 --dst_keys_dir ".acrakeys.v2"
 ```
 
-You need to put the master key to the source key store into `SRC_ACRA_MASTER_KEY`
+You need to put the master key to the source keystore into `SRC_ACRA_MASTER_KEY`
 and the destination master key into `DST_ACRA_MASTER_KEY`.
-New key store will be created at `.acrakeys.v2`.
+New keystore will be created at `.acrakeys.v2`.
 
 {{< hint info >}}
 **Note:**
 You can use the `--dry_run` option to test the migration and be sure that you can access all keys.
 {{< /hint >}}
 
-After migration is completed, check that Acra components can still operate with the new key store.
-You can set the path to the new key store using the `keys_dir` option
+After migration is completed, check that Acra components can still operate with the new keystore.
+You can set the path to the new keystore using the `keys_dir` option
 on the command-line or in the configuration file when launching Acra components.
-Once you're sure that your operations are not affected, you can swap the key store directories.
+Once you're sure that your operations are not affected, you can swap the keystore directories.
 
 <!--
 TODO: describe Acra EE migration?


### PR DESCRIPTION
Like in the code (cossacklabs/acra#401, cossacklabs/acra-enterprise#82), replace all uses with a single word for the sake of consistency. Spelling "keystore" as a single word more closely resembles command-line syntax, is similar to how we use "keypair", and avoids weird connotations with stores as in "marketplaces". If it were called "key storage" maybe it would be okay to spell it separately...