### PR TITLE
Prefer JCenter for installing AndroidThemis

### DIFF
--- a/themis/languages/java/installation-android.md
+++ b/themis/languages/java/installation-android.md
@@ -29,6 +29,10 @@ dependencies {
 }
 ```
 
+{{< hint note >}}
+If you experience difficulties with jcenter repository, try using maven instead: `maven { url "https://dl.bintray.com/cossacklabs/maven/" }`
+{{< /hint >}}
+
 Once JavaThemis is installed, you can [try out examples on your machine](../examples/).
 
 ## Building latest version from source

--- a/themis/languages/java/installation-android.md
+++ b/themis/languages/java/installation-android.md
@@ -19,15 +19,13 @@ repositories {
     // Repositories for JavaThemis dependencies:
     google()
     jcenter()
-    // CossackLabs Maven repository:
-    maven { url "https://dl.bintray.com/cossacklabs/maven/" }
 }
 
 dependencies {
     // Add JavaThemis as runtime dependency of your application.
     // Always pin the latest version, you can find it here:
     // https://bintray.com/cossacklabs/maven/themis
-    implementation 'com.cossacklabs.com:themis:0.12.0'
+    implementation 'com.cossacklabs.com:themis:0.13.1'
 }
 ```
 


### PR DESCRIPTION
* Remove CossackLabs repository from example build.gradle
* Update version in example

Now, there're two ways for updating Java examples (replace deprecated API calls with new ones, maybe update some deps' versions):
1) Only update the examples in [cossacklabs/themis-java-examples](https://github.com/cossacklabs/themis-java-examples). 
2) Update the examples and move them to [cossacklabs/themis/docs/examples](https://github.com/cossacklabs/themis/tree/master/docs/examples),
  removing [cossacklabs/themis-java-examples](https://github.com/cossacklabs/themis-java-examples) completely.
  In this case, we gonna need to fix few links in docs, so maybe wait sometime to update this PR and not create another one.