### PR TITLE
Update crypto export guidelines

### DIFF
--- a/themis/regulations/_index.md
+++ b/themis/regulations/_index.md
@@ -45,10 +45,10 @@ under the License Exception ENC Technology Software Unrestricted (TSU) exception
 (see the BIS Export Administration Regulations, Section 740.13)
 for both object code and source code.
 
-## Submissions to the App Store
+## Submissions to the App Store or Google Play
 
-If you’re using Themis as your means of encryption within your iOS/macOS app
-and intend to submit it to the Apple App Store,
+If you’re using Themis as your means of encryption within your iOS/macOS/Android app
+and intend to submit it to the Apple App Store or Google Play,
 your encryption falls under the “open source” exception.
 
 {{< hint warning >}}
@@ -59,4 +59,4 @@ we strongly recommend that you seek professional legal advice.
 
 Generally, you should indicate that you’re using encryption
 and submit annual self-classification reports.
-Read more about [submitting applications using Themis to the App Store](/themis/regulations/apple-crypto-regulations/).
+Read more about [submitting applications using Themis](/themis/regulations/apple-crypto-regulations/).

--- a/themis/regulations/apple-crypto-regulations.md
+++ b/themis/regulations/apple-crypto-regulations.md
@@ -5,6 +5,20 @@ title: US crypto export regulations
 
 # US crypto export regulations for Themis
 
+When you distribute apps via platforms like App Store or Google Play,
+the binaries are typically hosted on servers located within US, owned by US companies.
+United States laws treat this activity as export, which is heavily regulated for cryptography.
+
+However, typical Themis use cases fall under “open source” exceptions.
+This makes compliance much easier if your app is open source as well.
+
+{{ note warning }}
+**Note:**
+If your app is not open source or is not distributed free of charge,
+we strongly recommend that you seek professional legal advice.
+{{ /note }}
+
+
 ## Submitting apps to App Store
 
 If your application uses Themis and you want to submit it to the Apple App Store,

--- a/themis/regulations/apple-crypto-regulations.md
+++ b/themis/regulations/apple-crypto-regulations.md
@@ -1,9 +1,9 @@
 ---
 weight: 1
-title:  App Store requirements
+title: App Store requirements
 ---
 
-# Apple encryption export regulations for Themis
+# US crypto export regulations for Themis when submitting to App Store
 
 If your application uses Themis and you want to submit it to the Apple App Store,
 you are required to do the following:
@@ -28,7 +28,18 @@ Read more in the official [Apple export compliance overview](https://help.apple.
 and [BIS guidelines](https://bis.doc.gov/index.php/policy-guidance/encryption/1-encryption-items-not-subject-to-the-ear)
 (you might need to use a VPN to access it).
 
-#### Submitting an annual self-classification report to Apple
+
+# US crypto export regulations for Themis when submitting to Google Play
+
+If your application uses Themis and you want to submit it to the Google Play,
+you are required to do the following:
+
+1. Send an annual (year-end) self-classification report to the US government
+    to comply with the [encryption export regulations](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations).
+
+Read more in the [Google Play guidelines](https://support.google.com/googleplay/android-developer/answer/113770?hl=en).
+
+## Submitting an annual self-classification report to BIS
 
 The procedure is as follows.
 
@@ -54,7 +65,7 @@ Please see
 [How to file an Annual Self Classification Report](https://www.bis.doc.gov/index.php/policy-guidance/encryption/4-reports-and-reviews/a-annual-self-classification)
 by the Bureau of Industry and Security for more details.
 
-#### Additional resources
+## Additional resources
 
 For further guidance, see these resources:
 

--- a/themis/regulations/apple-crypto-regulations.md
+++ b/themis/regulations/apple-crypto-regulations.md
@@ -1,9 +1,11 @@
 ---
 weight: 1
-title: App Store requirements
+title: US crypto export regulations
 ---
 
-# US crypto export regulations for Themis when submitting to App Store
+# US crypto export regulations for Themis
+
+## Submitting apps to App Store
 
 If your application uses Themis and you want to submit it to the Apple App Store,
 you are required to do the following:
@@ -28,14 +30,13 @@ Read more in the official [Apple export compliance overview](https://help.apple.
 and [BIS guidelines](https://bis.doc.gov/index.php/policy-guidance/encryption/1-encryption-items-not-subject-to-the-ear)
 (you might need to use a VPN to access it).
 
-
-# US crypto export regulations for Themis when submitting to Google Play
+## Submitting apps to Google Play
 
 If your application uses Themis and you want to submit it to the Google Play,
 you are required to do the following:
 
-1. Send an annual (year-end) self-classification report to the US government
-    to comply with the [encryption export regulations](https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations).
+ 1. Send an annual (year-end) self-classification report to the US government
+    to comply with the encryption export regulations.
 
 Read more in the [Google Play guidelines](https://support.google.com/googleplay/android-developer/answer/113770?hl=en).
 


### PR DESCRIPTION
Add section about Google Play.

P.S. I'd like to rename page URL from `apple-crypto-regulations/` to `us-crypto-export-compliance/` and setup redirect, however it requires to change file names and setup redirect in hugo configs, so I plan to handle this later.