### PR TITLE
Reference implementation of Soter container

### DIFF
--- a/themis/spec/common/soter-container.go
+++ b/themis/spec/common/soter-container.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"math"
+)
+
+// SoterContainer is a lightweight data container with basic integrity checks.
+type SoterContainer struct {
+	TagBytes [4]byte
+	Payload  []byte
+}
+
+// Serialize this container, append it to the given buffer, and return it.
+func (container *SoterContainer) Serialize(buffer []byte) []byte {
+	buffer = append(buffer, container.TagBytes[:]...)
+	buffer = append(buffer, container.lengthBytes()...)
+	buffer = append(buffer, container.Checksum()...)
+	buffer = append(buffer, container.Payload...)
+	return buffer
+}
+
+func (container *SoterContainer) lengthBytes() []byte {
+	// Length field includes the length of the header too
+	const maxPayloadLength = math.MaxUint32 - 12
+	if len(container.Payload) > maxPayloadLength {
+		panic("Soter container payload too long")
+	}
+	length := make([]byte, 4)
+	binary.BigEndian.PutUint32(length, uint32(12+len(container.Payload)))
+	return length
+}
+
+// Checksum computes CRC checksum of this container.
+func (container *SoterContainer) Checksum() []byte {
+	// CRC-32C
+	crc := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	crc.Write(container.TagBytes[:])
+	crc.Write(container.lengthBytes())
+	crc.Write(make([]byte, 4)) // assume "checksum" is zero
+	crc.Write(container.Payload)
+	checksum := crc.Sum(nil)
+
+	// Soter uses *reflected* Castagnoli CRC
+	checksum[0], checksum[3] = checksum[3], checksum[0]
+	checksum[1], checksum[2] = checksum[2], checksum[1]
+
+	return checksum
+}
+
+// ParseSoterContainer extracts and validates a Soter container from the buffer.
+// It also returns the remaining part of the buffer.
+func ParseSoterContainer(buffer []byte) (*SoterContainer, []byte) {
+	// Check that the buffer is at least big enough for a Soter container.
+	if len(buffer) < 12 {
+		return nil, buffer
+	}
+
+	// Read the header fields.
+	var tagBytes [4]byte
+	copy(tagBytes[:], buffer[0:4])
+	length := binary.BigEndian.Uint32(buffer[4:8])
+	checksum := buffer[8:12]
+
+	// Check that we have enough remaining for the alleged payload.
+	if len(buffer) < int(length) {
+		return nil, buffer
+	}
+	payload := buffer[12:length]
+	remaining := buffer[length:]
+
+	// Verify the checksum.
+	container := &SoterContainer{tagBytes, payload}
+	if !bytes.Equal(checksum, container.Checksum()) {
+		return nil, buffer
+	}
+	return container, remaining
+}
+
+// NewSoterContainer makes a new Soter container with given tag and payload.
+//
+// This is a convenience method so that you don't have to deal with arrays,
+// as most of Themis tags are actually strings.
+func NewSoterContainer(tag string, payload []byte) *SoterContainer {
+	if len(tag) != 4 {
+		panic("Soter container tag must be 4 bytes long")
+	}
+	var tagBytes [4]byte
+	copy(tagBytes[:], tag)
+	return &SoterContainer{tagBytes, payload}
+}
+
+// SerializeSoterContainer packs the tagged payload into a Soter container.
+//
+// This is a convenience method to quickly pack the payload into a byte slice.
+func SerializeSoterContainer(tag string, payload []byte) []byte {
+	return NewSoterContainer(tag, payload).Serialize(nil)
+}
+
+// Tag returns Soter container tag as a string.
+func (container *SoterContainer) Tag() string {
+	return string(container.TagBytes[:])
+}

--- a/themis/spec/common/soter-container_test.go
+++ b/themis/spec/common/soter-container_test.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestExampleContainer(t *testing.T) {
+	containerB64 := "VUVDMgAAAC1s1W74A6Sx9yhDygNh4YEb0LShLZrEgTosYF2yRVG4pHGoaa6N"
+	containerBytes, _ := base64.StdEncoding.DecodeString(containerB64)
+
+	container, remaining := ParseSoterContainer(containerBytes)
+	if container == nil {
+		t.Fatal("not a Soter container")
+	}
+	if len(remaining) != 0 {
+		t.Error("unexpected trailing bytes")
+	}
+
+	if container.Tag() != "UEC2" {
+		t.Error("invalid tag")
+		t.Log("actual:  ", container.Tag())
+		t.Log("expected:", "UEC2")
+	}
+
+	if len(container.Payload) != 33 {
+		t.Error("invalid payload length")
+		t.Log("actual:  ", len(container.Payload))
+		t.Log("expected:", 33)
+	}
+}

--- a/themis/spec/common/soter-container_test.go
+++ b/themis/spec/common/soter-container_test.go
@@ -6,6 +6,12 @@ import (
 )
 
 func TestExampleContainer(t *testing.T) {
+	// This is an EC public key for Themis, the one dissected in the specification.
+	// You can use Themis command-line tools to generate a new keypair:
+	//
+	//     go run docs/examples/go/secure_keygen.go | tail -n +2
+	//
+	// See https://docs.cossacklabs.com/themis/debugging/cli-utilities/
 	containerB64 := "VUVDMgAAAC1s1W74A6Sx9yhDygNh4YEb0LShLZrEgTosYF2yRVG4pHGoaa6N"
 	containerBytes, _ := base64.StdEncoding.DecodeString(containerB64)
 


### PR DESCRIPTION
Okay, here's my stupid idea. In addition to specs with prose, provide users with a reference implementation of whatever is described. Some people are better at understanding concepts through code. Plus, this provides an "executable specification" and tests. I have found this invaluable when writing Secure Cell spec: that caught quite a few mistakes and misconceptions that I had about its implementation.

(History-savvy people here could have found parallels between this and the concept of "literate programming". Indeed, if only Knuth's ideas caught up, this would have been a perfect opportunity for that approach. Unfortunately, it's not really popular to have good tooling.)

The reference implementation is written in Go. Aside from an obvious reasons having to do with Cossack Labs being a Go shop, this choice has a number of other benefits:

  - very good standard library, with a lot of cryptographic primitives available which will come very handy later
  - readable to most programmers who are familiar with C syntax
  - almost immediately executable if you copy-paste the sample code, thanks to "push to GitHub to publish a package" approach
  - reference implementation can actually reuse its own code for different cryptosystems

Unfortunately, you can't run this on Go Playground without much hassle, but that would have been amazing.

Now, note that "reference implementation" is different from the "official GoThemis source code". The overriding objective here is to illustrate key points in Themis algorithms. Readability and correctness are the main focus of the reference implementation. Performance, usability, good error reporting, feature completeness – all of this can be sacrificed for the sake of brevity and clarity of the code.

Themis Core's C code is anything but easy to understand cryptography. Since even its maintainers make mistakes when deciphering code paths leading to arcane OpenSSL invocations, any cryptography audit would be pretty expensive for it. Hopefully, this reference implementation can serve as a better way to understand the cryptography behind Themis.

Okay, so... Here's an implementation of Soter container for starters. Let's link to it for the implementation details and replace the snippet with something shorter (which still invokes the same code). The reader should be able to copy the snippet, run it with `go run`, and see the output which corresponds to whatever is there in the spec prose.

What do you all think?

Dependencies:
- [X] #34