### PR TITLE
Update Java/Kotlin example project locations

### DIFF
--- a/themis/languages/java/examples.md
+++ b/themis/languages/java/examples.md
@@ -5,15 +5,14 @@ title:  Examples
 
 # Example projects with JavaThemis
 
-Once you have installed JavaThemis
-(for [Android](../installation-android/) or [desktop](../installation-desktop/) development),
+Once you have [installed JavaThemis](../installation-desktop/) for desktop systems
 it’s time to give it some action!
 
 ## Code samples
 
-[Themis Java examples](https://github.com/cossacklabs/themis-java-examples)
-illustrate how to integrate JavaThemis into Android and desktop Java projects
-and how JavaThemis API can be used:
+See the [`docs/examples/java`](https://github.com/cossacklabs/themis/tree/master/docs/examples/java)
+directory on GitHub for an sample project with JavaThemis for desktop systems.
+There you can find examples of JavaThemis API:
 
   - data encryption using Secure Cell
   - exchange messages using Secure Message
@@ -21,11 +20,6 @@ and how JavaThemis API can be used:
 
 You can also take a look at unit tests
 in [JavaThemis source code](https://github.com/cossacklabs/themis/tree/master/tests/themis/wrappers/android/com/cossacklabs/themis/test).
-
-## Blog posts
-
-You can read our blog post on [building encrypted chat service](https://www.cossacklabs.com/building-secure-chat),
-which includes Android client using Secure Session and Secure Cell.
 
 ## Debugging aids
 

--- a/themis/languages/kotlin/examples.md
+++ b/themis/languages/kotlin/examples.md
@@ -5,21 +5,14 @@ title:  Examples
 
 # Example projects with JavaThemis
 
-Once you have installed JavaThemis
-(for [Android](../installation-android/) or [desktop](../installation-desktop/) development),
+Once you have [installed JavaThemis](../installation-android/) for Android
 it’s time to give it some action!
-
-{{< hint info >}}
-JavaThemis is implemented in Java and provides Kotlin API via JVM interop.
-Kotlin support is currently in development
-so some examples may be available only in Java.
-{{< /hint >}}
 
 ## Code samples
 
-[Themis Java examples](https://github.com/cossacklabs/themis-java-examples)
-illustrate how to integrate JavaThemis into Android and desktop Java projects
-and how JavaThemis API can be used:
+See the [`docs/examples/android`](https://github.com/cossacklabs/themis/tree/master/docs/examples/android)
+directory on GitHub for an sample project with JavaThemis for Android.
+There you can find examples of JavaThemis API:
 
   - data encryption using Secure Cell
   - exchange messages using Secure Message


### PR DESCRIPTION
Now that these examples have been moved to the main repository (https://github.com/cossacklabs/themis/pull/813, https://github.com/cossacklabs/themis/pull/816), let's revise the documentation a bit. Since Android example is not Kotlin example, let's focus Kotlin docs on Android use-case while Jave examples are meant for "desktop systems" (actually, more like server systems, but you know, not mobile ones)