### PR TITLE
Update more Java/Kotlin example project locations

### DIFF
--- a/themis/languages/java/features.md
+++ b/themis/languages/java/features.md
@@ -562,9 +562,9 @@ the only difference between the two is in who starts the communication.
 After the session is established, either party can send messages to their peer whenever it wishes to.
 
 {{< hint info >}}
-Take a look at code samples in the [Java Examples](https://github.com/cossacklabs/themis-java-examples)
+Take a look at [example projects in Java](../examples/)
 and [Secure Mobile WebSocket](https://github.com/cossacklabs/mobile-websocket-example)
-repositories on GitHub.
+repository on GitHub.
 There you can find examples of Secure Session setup and usage in all modes.
 {{< /hint >}}
 

--- a/themis/languages/java/installation-desktop.md
+++ b/themis/languages/java/installation-desktop.md
@@ -177,5 +177,5 @@ so you do not have to install Gradle manually.
 The resulting JAR file `java-themis-X.Y.Z.jar` will be placed into `src/wrappers/themis/java/build/libs`.
 You then need to add it to your project.
 
-See [JavaThemis examples](https://github.com/cossacklabs/themis-java-examples)
+See [JavaThemis examples](../../java/examples/)
 for illustration of how to integrate JavaThemis into your project.

--- a/themis/languages/kotlin/features.md
+++ b/themis/languages/kotlin/features.md
@@ -549,9 +549,9 @@ the only difference between the two is in who starts the communication.
 After the session is established, either party can send messages to their peer whenever it wishes to.
 
 {{< hint info >}}
-Take a look at code samples in the [Java Examples](https://github.com/cossacklabs/themis-java-examples)
+Take a look at [example projects in Kotlin](../examples/)
 and [Secure Mobile WebSocket](https://github.com/cossacklabs/mobile-websocket-example)
-repositories on GitHub.
+repository on GitHub.
 There you can find examples of Secure Session setup and usage in all modes.
 {{< /hint >}}
 


### PR DESCRIPTION
Replace links to deprecated JavaThemis example repo with internal links to relevant documentation page about examples.

I'm sorry, #44 did not do everything. I went to check out how that renders, saw more links, and decided to `git grep` URLs to the old repo.

I've updated links in developer documentation. However, some links to the old repo still remain:
- [Credits and honourable* mentions](https://docs.cossacklabs.com/themis/community/credits/)
- [Projects that use Themis](https://docs.cossacklabs.com/themis/community/projects-that-use-themis/#sample-projects)

I think we can leave them as is for posterity, they won't confuse anyone.

<sup>
_______<br>
* Firefox autocorrects this to “nonburnable”. Works for me, eh.
</sup>