### PR TITLE
List all supported Go versions

### DIFF
--- a/themis/languages/go/_index.md
+++ b/themis/languages/go/_index.md
@@ -26,7 +26,7 @@ bookCollapseSection: true
 ## Supported Go versions
 
 GoThemis is tested and supported on the current stable Go versions
-(Go 1.11–1.14).
+(Go 1.11–1.16).
 
 ## Getting started
 


### PR DESCRIPTION
Add Go 1.15 and 1.16 to the list.

- https://github.com/cossacklabs/themis/pull/843