### PR TITLE
Acra TLS documentation

### DIFF
--- a/acra/configuring-maintaining/_index.md
+++ b/acra/configuring-maintaining/_index.md
@@ -2,3 +2,5 @@
 title: Configuring & maintaining
 bookCollapseSection: true
 ---
+
+# Configuring & maintaining

--- a/acra/configuring-maintaining/tls/_index.md
+++ b/acra/configuring-maintaining/tls/_index.md
@@ -11,7 +11,7 @@ bookCollapseSection: true
 
 * `--tls_auth=<mode>`
 
-  Set authentication mode that will be used in TLS connection with AcraConnector and database.
+  Set authentication mode that will be used for TLS connection.
 
   * `0` — do not request client certificate, ignore it if received
   * `1` — request client certificate, but don't require it
@@ -23,19 +23,24 @@ bookCollapseSection: true
 
 * `--tls_key=<filename>`
 
-  Path to private key that will be used in AcraServer's TLS handshake
-  with AcraConnector as server's key and database as client's key.
+  Path to private key that will be used for TLS handshake.
+  Should correspond to the certificate configured with `--tls_cert`.
   Empty by default.
 
 * `--tls_cert=<filename>`
 
-  Path to TLS certificate, will be sent to other peer during handshake.
+  Path to TLS certificate that will be sent to other peers during handshake.
   Empty by default.
+
+  In case of AcraServer, it will be sent to clients (AcraConnector, AcraTranslator) and to server (database).
 
 * `--tls_ca=<filename>`
 
   Path to additional CA certificate for AcraConnector and database certificate validation.
   Empty by default.
+
+  In case of AcraServer, it will be used to validate both client (AcraConnector, AcraTranslator) certificates
+  and server (database) ones.
 
 ## AcraConnector specific flags
 
@@ -53,7 +58,7 @@ bookCollapseSection: true
 
 * `--tls_client_auth=<mode>`
 
-  Set authentication mode that will be used in TLS connection with AcraConnector.
+  Set authentication mode that will be used for TLS connection with AcraConnector.
   Possible values are the same as for `--tls_auth`.
   Default is `-1` which means "take value of `--tls_auth`".
 
@@ -84,14 +89,15 @@ bookCollapseSection: true
 
 * `--tls_database_auth=<mode>`
 
-  Set authentication mode that will be used in TLS connection with database.
+  Set authentication mode that will be used for TLS connection with database.
   Possible values are the same as for `--tls_auth`.
   Overrides the `--tls_auth` setting.
   Default is `-1` which means "take value of `--tls_auth`".
 
 * `--tls_database_key=<filename>`
 
-  Path to private key of the TLS certificate used to connect to database (see `--tls_database_cert`).
+  Path to private key that will be used for TLS handshake with database.
+  Should correspond to the certificate configured with `--tls_database_cert`.
   Empty by default.
 
 * `--tls_database_cert=<filename>`
@@ -144,4 +150,4 @@ And if certificate does not contain OCSP URLs, it won't be validated using OCSP 
 
 ## PKI
 
-We have a dedicated page about public key infrastructure, located [here](/acra-in-depth/security-design/pki).
+We have a dedicated page about public key infrastructure, located [here](/acra-in-depth/security-design/pki-INVALID).

--- a/acra/configuring-maintaining/tls/_index.md
+++ b/acra/configuring-maintaining/tls/_index.md
@@ -3,11 +3,131 @@ title: TLS
 bookCollapseSection: true
 ---
 
-
-
 # TLS
 
-## Certificate validation
+## Common TLS flags
+
+(common for `acra-connector`, `acra-server`, `acra-translator`)
+
+* `--tls_auth=<mode>`
+
+  Set authentication mode that will be used in TLS connection with AcraConnector and database.
+
+  * `0` — do not request client certificate, ignore it if received
+  * `1` — request client certificate, but don't require it
+  * `2` — expect to receive at least one certificate to continue the handshake
+  * `3` — don't require client certificate, but validate it if client actually sent it
+  * `4` — (default) request and validate client certificate
+
+  These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
+
+* `--tls_key=<filename>`
+
+  Path to private key that will be used in AcraServer's TLS handshake
+  with AcraConnector as server's key and database as client's key.
+  Empty by default.
+
+* `--tls_cert=<filename>`
+
+  Path to TLS certificate, will be sent to other peer during handshake.
+  Empty by default.
+
+* `--tls_ca=<filename>`
+
+  Path to additional CA certificate for AcraConnector and database certificate validation.
+  Empty by default.
+
+## AcraConnector specific flags
+
+* `--acraserver_tls_transport_enable={true|false}`
+
+  Enable TLS to encrypt transport between AcraConnector and AcraServer.
+  Default is `false` which means "use SecureSession instead".
+
+## AcraServer specific flags
+
+* `--acraconnector_tls_transport_enable={true|false}`
+
+  Enable TLS to encrypt transport between AcraConnector and AcraServer.
+  Default is `false` which means "use SecureSession instead".
+
+* `--tls_client_auth=<mode>`
+
+  Set authentication mode that will be used in TLS connection with AcraConnector.
+  Possible values are the same as for `--tls_auth`.
+  Default is `-1` which means "take value of `--tls_auth`".
+
+  Overrides the `--tls_auth` setting.
+
+* `--tls_client_key=<filename>`
+
+  Path to private key of the TLS certificate presented to AcraConnectors (see `--tls_client_cert`).
+  Empty by default.
+
+* `--tls_client_cert=<filename>`
+
+  Path to server TLS certificate presented to AcraConnectors (overrides `--tls_cert`).
+  Empty by default.
+
+* `--tls_client_ca=<filename>`
+
+  Path to additional CA certificate for AcraConnector certificate validation (setup if AcraConnector certificate CA is different from database certificate CA).
+  Empty by default.
+
+* `--tls_client_id_from_cert={true|false}`
+
+  Extract clientID from TLS certificate.
+  Take TLS certificate from AcraConnector's connection if `--acraconnector_tls_transport_enable` is `true`;
+  otherwise take TLS certificate from application's connection if `--acraconnector_transport_encryption_disable` is `true`.
+  Can't be used with `--tls_client_auth=0` or `--tls_auth=0`.
+  Default is `false`.
+
+* `--tls_database_auth=<mode>`
+
+  Set authentication mode that will be used in TLS connection with database.
+  Possible values are the same as for `--tls_auth`.
+  Overrides the `--tls_auth` setting.
+  Default is `-1` which means "take value of `--tls_auth`".
+
+* `--tls_database_key=<filename>`
+
+  Path to private key of the TLS certificate used to connect to database (see `--tls_database_cert`).
+  Empty by default.
+
+* `--tls_database_cert=<filename>`
+
+  Path to client TLS certificate shown to database during TLS handshake (overrides `--tls_cert`).
+  Empty by default.
+
+* `--tls_database_ca=<filename>`
+
+  Path to additional CA certificate for database certificate validation
+  (setup if database certificate CA is different from AcraConnector certificate CA).
+  Empty by default.
+
+* `--tls_database_sni=<SNI>`
+
+  Expected Server Name (SNI) from database.
+  Empty by default which means "don't check the SNI sent by database".
+
+* `--tls_db_sni=<SNI>`
+
+  Expected Server Name (SNI) from database (deprecated, use `--tls_database_sni` instead).
+
+## Other TLS flags
+
+* `--tls_identifier_extractor_type=<type>`
+
+  Decide which field of TLS certificate to use as ClientID.
+
+  * `distinguished_name` — (default) certificate Distinguished Name (DN)
+  * `serial_number` — certificate serial number
+
+  {{< hint warning >}}
+  Only for `acra-server` and `acra-translator`
+  {{< /hint >}}
+
+## Certificate validation for revocation
 
 Acra services can be configured to validate other peers certificate during TLS handshake.
 
@@ -21,3 +141,7 @@ Or disabled completely.
 
 By dafault Acra will perform validation only if the certificate itself contains OCSP or CRL metadata.
 And if certificate does not contain OCSP URLs, it won't be validated using OCSP protocol. Same applies for CRL.
+
+## PKI
+
+We have a dedicated page about public key infrastructure, located [here](/acra-in-depth/security-design/pki).

--- a/acra/configuring-maintaining/tls/_index.md
+++ b/acra/configuring-maintaining/tls/_index.md
@@ -2,3 +2,22 @@
 title: TLS
 bookCollapseSection: true
 ---
+
+
+
+# TLS
+
+## Certificate validation
+
+Acra services can be configured to validate other peers certificate during TLS handshake.
+
+This feature is currently implemented for `acra-connector`, `acra-server` and `acra-translator`.
+
+There are two methods for certificate validation.
+They are configured separately and can be enabled simultaneously.
+Or disabled completely.
+* [OCSP (Online Certificate Status Protocol)](ocsp)
+* [CRL (Certificate Revocation List)](crl)
+
+By dafault Acra will perform validation only if the certificate itself contains OCSP or CRL metadata.
+And if certificate does not contain OCSP URLs, it won't be validated using OCSP protocol. Same applies for CRL.

--- a/acra/configuring-maintaining/tls/cert_gen_with_openssl.md
+++ b/acra/configuring-maintaining/tls/cert_gen_with_openssl.md
@@ -1,0 +1,163 @@
+---
+weight: 3
+title: Certificate generation with OpenSSL
+bookCollapseSection: true
+---
+
+# Certificate generation with OpenSSL
+
+Here you will see few tips about how certificates can be generated using `openssl` CLI tool.
+
+{{< hint warning >}}
+This is more like a collection of tips.
+In real world you have to make sure you keep private keys safe.
+Make sure the certificate extensions are properly configured.
+Make sure apps that use these certificates are properly configured.
+A lot of things require attention in order to work as expected and remain secure.
+{{< /hint >}}
+
+Since there are some parameters we cannot configure with CLI flags, we need to create own configuration file.
+Here it is, simple `openssl.cnf`, without intermediate CAs:
+```
+# This section is required by OpenSSL, but we specify DN on the command line,
+# so here an empty placeholder is used.
+[ req ]
+distinguished_name = req_dn
+
+[ req_dn ]
+
+# X.509 v3 extensions for issued certificates
+[ v3_req ]
+basicConstraints = CA:false
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = DNS:localhost
+
+# X.509 v3 extensions for CA certificate
+[ v3_ca ]
+basicConstraints = critical,CA:true
+subjectAltName = DNS:localhost
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+dir = .
+database = $dir/index.txt
+serial = $dir/serial
+
+certificate = $dir/ca.crt.pem
+private_key = $dir/ca.key.pem
+
+default_md = sha256
+default_crl_days = 30
+policy = policy_anything
+
+[ policy_anything ]
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+```
+
+## Create self-signed CA certificate
+
+```
+openssl req \
+    -x509 -sha256 -nodes -days 365 -newkey rsa:4096 \
+    -keyout ca.key.pem \
+    -out ca.crt.pem \
+    -subj '/C=GB/ST=London/L=London/O=Global Security/OU=IT/CN=Test CA'
+
+# Create certificate database, will be needed when signing CSRs
+touch index.txt
+```
+
+## Show generated certificate in readable format
+
+```
+openssl x509 -noout -text -in ca.crt.pem
+```
+Example output:
+```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            64:28:80:32:72:4e:a6:5a:cc:31:bb:00:e5:bc:31:48:62:b1:e9:1f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = GB, ST = London, L = London, O = Global Security, OU = IT, CN = Test CA
+        Validity
+            Not Before: Jul  5 07:37:16 2021 GMT
+            Not After : Jul  5 07:37:16 2022 GMT
+        Subject: C = GB, ST = London, L = London, O = Global Security, OU = IT, CN = Test CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:98:86:b9:17:5e:d2:80:64:68:83:4a:51:fd:c1:
+                    ### some lines skipped ###
+                    38:73:71:ad:64:5f:76:74:17:41:0d:5e:bf:e3:5a:
+                    a6:64:b1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                80:17:42:A5:C4:C5:B5:5E:14:82:7D:72:74:25:0A:AB:C8:9F:E3:2E
+            X509v3 Authority Key Identifier:
+                keyid:80:17:42:A5:C4:C5:B5:5E:14:82:7D:72:74:25:0A:AB:C8:9F:E3:2E
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+    Signature Algorithm: sha256WithRSAEncryption
+         8e:77:bf:da:4b:74:8c:c8:23:a2:a8:5b:9c:88:1b:58:90:96:
+         ### some lines skipped ###
+         f4:71:d2:7d:2c:6e:ae:01:5b:8c:2f:f8:70:a5:c5:b6:55:2e:
+         e9:00:62:5f:89:c3:0d:00
+```
+
+## Generate RSA key for a certificate
+
+```
+openssl genrsa -out cert1.key.pem 2048
+```
+
+## Create Certificate Signing Request
+
+```
+openssl req -new \
+    -key cert1.key.pem \
+    -out cert1.csr.pem \
+    -subj '/C=GB/ST=London/L=London/O=Global Security/OU=IT/CN=Test certificate 1'
+```
+
+## Sign Certificate Signing Request
+
+```
+openssl ca \
+    -config openssl.cnf \
+    -in cert1.csr.pem \
+    -out cert1.crt.pem \
+    -extensions v3_req \
+    -batch \
+    -outdir /tmp \
+    -rand_serial \
+    -notext \
+    -days 365
+
+# See signed certificate being added to database
+cat index.txt
+```
+Example content of `index.txt`:
+```
+V       220705074134Z           334E651762E338DB251AE2B5E8CF0150D5C8A824        unknown /C=GB/ST=London/L=London/O=Global Security/OU=IT/CN=Test certificate 1
+```
+
+What now?
+
+* `ca.crt.pem` is a CA certificate, can be used for options like `-tls_ca`
+* `cert1.crt.pem` is a leaf certificate signed by CA itself, can be used for `-tls_cert`
+* `cert1.key.pem` is a key corresponsing to `cert1.crt.pem`, can be used for `-tls_key`

--- a/acra/configuring-maintaining/tls/crl.md
+++ b/acra/configuring-maintaining/tls/crl.md
@@ -6,50 +6,94 @@ bookCollapseSection: true
 
 # TLS certificate validation using CRL
 
+Only [CRL v1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1) with basic fields is currently supported.
+This means Acra will be able to download CRL, verify it, and search for a certificate serial number there.
+But more advanced features like [CRL extensions](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2)
+(including [delta CRLs](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.4)) are not handled yet.
+
 CRL-related flags and their description. Work in `acra-connector`, `acra-server` and `acra-translator`.
 
-* `--tls_crl_cache_size=<count>` default `16`
-
-  How many CRLs to cache in memory. Use `0` to disable caching. Maximum is `1000000`.
-  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy
-
-* `--tls_crl_cache_time=<seconds>` default `0`
-
-  How long to keep CRLs cached, in seconds. Use `0` to disable caching. Maximum is `300` seconds
-
-* `--tls_crl_check_only_leaf_certificate=<true|false>` default `false`
-
-  This flag controls behavior of validator in cases when certificate chain contains more than two certificates (leaf + CA).
-  `true` will make validator only verify leaf certificate while `false` will make it check all certificates up to CA
-  (not including CA since it's already trusted).
-
-* `--tls_crl_client_url=""` default (empty)
-
-  CRL URL for incoming TLS connections to check client certificates.
-  Only available for `acra-server` where we have both client and server TLS connections.
-
-* `--tls_crl_database_url=""` default (enpty)
-
-  CRL URL for outcoming TLS connections to check database certificates.
-  Only available for `acra-server` where we have both client and server TLS connections.
-
-* `--tls_crl_from_cert=<use|trust|prefer|ignore>` default `prefer`
-
-  How to treat CRL URL described in certificate itself
-
-  * `use`: try URL(s) from certificate after the one from configuration (if set)
-  * `trust`: try first URL from certificate, if it does not contain checked certificate, stop further checks
-  * `prefer`: try URL(s) from certificate before the one from configuration (if set)
-  * `ignore`: completely ignore CRL URL(s) specified in certificate
-
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags
-
-* `--tls_crl_url`
+* `--tls_crl_url=<url>`
 
   URL of the Certificate Revocation List (CRL) to use.
+  Empty by default.
 
-  For `acra-server` it will work like `--tls_crl_client_url` and `--tls_ocsp_database_url`
+  Can be either `http://` or `file://` (for local files).
+  When using local file, Acra will simply read the file and won't monitor filesystem for changes afterwards.
+  Usual caching rules apply (see `--tls_crl_cache_time`).
+
+  For `acra-server` it will work like `--tls_crl_client_url` and `--tls_crl_database_url`
   passed simultaneously with same value.
 
   For `acra-connector` and `acra-translator` (that can only work as TLS clients)
   it will set CRL URL for validation of certificates sent by server.
+
+* `--tls_crl_client_url=<url>`
+
+  CRL URL for incoming TLS connections to check client certificates.
+  Empty by default.
+  {{< hint warning >}}
+  Only for `acra-server`
+  {{< /hint >}}
+
+* `--tls_crl_database_url=<url>`
+
+  CRL URL for outcoming TLS connections to check database certificates.
+  Empty by default.
+  {{< hint warning >}}
+  Only for `acra-server`
+  {{< /hint >}}
+
+* `--tls_crl_from_cert=<policy>`
+
+  How to treat CRL URL described in certificate itself
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore CRL URL(s) specified in certificate
+
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags.
+
+* `--tls_crl_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+* `--tls_crl_cache_size=<count>`
+
+  How many CRLs to cache in memory.
+  Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
+  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+
+* `--tls_crl_cache_time=<seconds>`
+
+  How long to keep CRLs cached, in seconds.
+  Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+
+## Make `openssl` include CRL URL when signing CSR
+
+When using `openssl` to sign Certificate Signing Requests,
+an extension can be added to make certificate include CRL URL:
+```
+# in section that contains used X.509 v3 extensions
+crlDistributionPoints = @crl_section
+
+# section that describes CRL file URL
+[ crl_section ]
+URI.0 = http://127.0.0.1:8080/crl.pem
+```
+
+## Generating CRL file with `openssl`
+
+If you have custom openssl configuration file, if you are able to run command like
+`openssl ca ...` and have signed certificates appear in certificate database (usually called `index.txt`),
+you can also use `openssl` to generate CRL v1:
+```
+openssl ca -gencrl -config openssl.cnf -crldays 1 -out crl.pem
+```
+Then, tell Acra to use it with `-tls_crl_url=file:///path/to/crl.pem`.
+
+Or launch HTTP server and make it host the CRL file.

--- a/acra/configuring-maintaining/tls/crl.md
+++ b/acra/configuring-maintaining/tls/crl.md
@@ -11,7 +11,7 @@ This means Acra will be able to download CRL, verify it, and search for a certif
 But more advanced features like [CRL extensions](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2)
 (including [delta CRLs](https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.4)) are not handled yet.
 
-CRL-related flags and their description. Work in `acra-connector`, `acra-server` and `acra-translator`.
+CRL-related flags and their description. Works for `acra-connector`, `acra-server` and `acra-translator`.
 
 * `--tls_crl_url=<url>`
 
@@ -61,6 +61,10 @@ CRL-related flags and their description. Work in `acra-connector`, `acra-server`
 
   * `true` — validate only leaf certificate
   * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there's no CRL URL configured and no CRL URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know which CRLs could used for validation.
 
 * `--tls_crl_cache_size=<count>`
 

--- a/acra/configuring-maintaining/tls/crl.md
+++ b/acra/configuring-maintaining/tls/crl.md
@@ -1,0 +1,55 @@
+---
+weight: 2
+title: CRL
+bookCollapseSection: true
+---
+
+# TLS certificate validation using CRL
+
+CRL-related flags and their description. Work in `acra-connector`, `acra-server` and `acra-translator`.
+
+* `--tls_crl_cache_size=<count>` default `16`
+
+  How many CRLs to cache in memory. Use `0` to disable caching. Maximum is `1000000`.
+  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy
+
+* `--tls_crl_cache_time=<seconds>` default `0`
+
+  How long to keep CRLs cached, in seconds. Use `0` to disable caching. Maximum is `300` seconds
+
+* `--tls_crl_check_only_leaf_certificate=<true|false>` default `false`
+
+  This flag controls behavior of validator in cases when certificate chain contains more than two certificates (leaf + CA).
+  `true` will make validator only verify leaf certificate while `false` will make it check all certificates up to CA
+  (not including CA since it's already trusted).
+
+* `--tls_crl_client_url=""` default (empty)
+
+  CRL URL for incoming TLS connections to check client certificates.
+  Only available for `acra-server` where we have both client and server TLS connections.
+
+* `--tls_crl_database_url=""` default (enpty)
+
+  CRL URL for outcoming TLS connections to check database certificates.
+  Only available for `acra-server` where we have both client and server TLS connections.
+
+* `--tls_crl_from_cert=<use|trust|prefer|ignore>` default `prefer`
+
+  How to treat CRL URL described in certificate itself
+
+  * `use`: try URL(s) from certificate after the one from configuration (if set)
+  * `trust`: try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer`: try URL(s) from certificate before the one from configuration (if set)
+  * `ignore`: completely ignore CRL URL(s) specified in certificate
+
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags
+
+* `--tls_crl_url`
+
+  URL of the Certificate Revocation List (CRL) to use.
+
+  For `acra-server` it will work like `--tls_crl_client_url` and `--tls_ocsp_database_url`
+  passed simultaneously with same value.
+
+  For `acra-connector` and `acra-translator` (that can only work as TLS clients)
+  it will set CRL URL for validation of certificates sent by server.

--- a/acra/configuring-maintaining/tls/ocsp.md
+++ b/acra/configuring-maintaining/tls/ocsp.md
@@ -6,7 +6,7 @@ bookCollapseSection: true
 
 # TLS certificate validation using OCSP
 
-OCSP-related flags and their description. Work in `acra-connector`, `acra-server` and `acra-translator`.
+OCSP-related flags and their description. Works for `acra-connector`, `acra-server` and `acra-translator`.
 
 * `--tls_ocsp_url=<url>`
 
@@ -64,6 +64,10 @@ OCSP-related flags and their description. Work in `acra-connector`, `acra-server
 
   * `true` — validate only leaf certificate
   * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there's no OCSP URL configured and no OCSP URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know whom to ask about them.
 
 ## Make `openssl` include OCSP service URL when signing CSR
 

--- a/acra/configuring-maintaining/tls/ocsp.md
+++ b/acra/configuring-maintaining/tls/ocsp.md
@@ -8,48 +8,102 @@ bookCollapseSection: true
 
 OCSP-related flags and their description. Work in `acra-connector`, `acra-server` and `acra-translator`.
 
-* `--tls_ocsp_check_only_leaf_certificate=<true|false>` default `false`
-
-  This flag controls behavior of validator in cases when certificate chain contains more than two certificates (leaf + CA).
-  `true` will make validator only verify leaf certificate while `false` will make it check all certificates up to CA
-  (not including CA since it's already trusted).
-
-* `--tls_ocsp_client_url=""` default (empty)
-
-  OCSP service URL for incoming TLS connections to check client certificates.
-  Only available for `acra-server` where we have both client and server TLS connections.
-
-* `--tls_ocsp_database_url=""` default (empty)
-
-  OCSP service URL for outcoming TLS connections to check database certificates.
-  Only available for `acra-server` where we have both client and server TLS connections.
-
-* `--tls_ocsp_from_cert=<use|trust|prefer|ignore>` default `prefer`
-
-  How to treat OCSP server URL described in certificate itself
-
-  * `use`: try URL(s) from certificate after the one from configuration (if set)
-  * `trust`: try URL(s) from certificate, if server returns "Valid", stop further checks
-  * `prefer`: try URL(s) from certificate before the one from configuration (if set)
-  * `ignore`: completely ignore OCSP URL(s) specified in certificate
-
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags
-
-* `--tls_ocsp_required=<denyUnknown|allowUnknown|requireGood>` default `denyUnknown`
-
-  How to treat situation when OCSP server doesn't know about requested certificate and returns "Unknown"
-
-  `denyUnknown`: consider "Unknown" response an error, certificate validation will fail
-  `allowUnknown`: reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  `requireGood`: require all known OCSP servers to respond "Good" in order to allow certificate and
-  continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
-
-* `--tls_ocsp_url=""` default (empty)
+* `--tls_ocsp_url=<url>`
 
   OCSP service URL.
+  Empty by default.
+
+  Should point to HTTP server that accepts `application/ocsp-request` MIME type
+  and responds with `application/ocsp-response`.
 
   For `acra-server` it will work like `--tls_ocsp_client_url` and `--tls_ocsp_database_url`
   passed simultaneously with same value.
 
   For `acra-connector` and `acra-translator` (that can only work as TLS clients)
   it will set OCSP URL for validation of certificates sent by server.
+
+* `--tls_ocsp_client_url=<url>`
+
+  OCSP service URL for incoming TLS connections to check client certificates.
+  Empty by default.
+  {{< hint warning >}}
+  Only for `acra-server`
+  {{< /hint >}}
+
+* `--tls_ocsp_database_url=<url>`
+
+  OCSP service URL for outcoming TLS connections to check database certificates.
+  Empty by default.
+  {{< hint warning >}}
+  Only for `acra-server`
+  {{< /hint >}}
+
+* `--tls_ocsp_required=<policy>`
+
+  How to handle situation when OCSP server doesn't know about requested certificate and returns "Unknown".
+
+  * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
+  * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
+    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+
+* `--tls_ocsp_from_cert=<policy>`
+
+  How to treat OCSP server URL described in certificate itself.
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore OCSP URL(s) specified in certificate
+
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags.
+
+* `--tls_ocsp_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+## Make `openssl` include OCSP service URL when signing CSR
+
+When using `openssl` to sign Certificate Signing Requests,
+an extension can be added to make certificate include OCSP service(s) URL(s):
+```
+# in section that contains used X.509 v3 extensions
+authorityInfoAccess = @ocsp_section
+
+# section that describes OCSP service URL(s)
+[ ocsp_section ]
+OCSP;URI.0 = http://127.0.0.1:8080
+# OCSP;URI.1 = http://host:port and so on for additional OCSP URLs
+```
+
+## Running `openssl ocsp` server
+
+If you have custom openssl configuration file, if you are able to run command like
+`openssl ca ...` and have signed certificates appear in certificate database (usually called `index.txt`),
+you can launch this simple yet completely functional OCSP server:
+```
+openssl ocsp \
+    -port 8080 \
+    -index index.txt \
+    -rsigner ocsp-responder.crt.pem \
+    -rkey ocsp-responder.crt.key \
+    -CA ca.crt.pem \
+    -ignore_err
+```
+Flags `-rsigner` and `-rkey` describe certificate and private key of OCSP responder. The key will be used to sign the response.
+OCSP responder should be a certificate signed by the same CA that signed certificates we are responding about.
+In openssl configuration it should have `extendedKeyUsage = OCSPSigning` property.
+Also, CA certificate+key can be used instead of dedicated responder certificate+key.
+Flag `-CA` describes CA certificate that signed certificates we are answering about.
+
+And here is how to perform OCSP request, also using openssl:
+```
+openssl ocsp \
+    -CAfile ca.crt.pem \
+    -issuer ca.crt.pem \
+    -cert some_certificate.crt.pem \
+    -url http://127.0.0.1:8080
+```

--- a/acra/configuring-maintaining/tls/ocsp.md
+++ b/acra/configuring-maintaining/tls/ocsp.md
@@ -1,0 +1,55 @@
+---
+weight: 1
+title: OCSP
+bookCollapseSection: true
+---
+
+# TLS certificate validation using OCSP
+
+OCSP-related flags and their description. Work in `acra-connector`, `acra-server` and `acra-translator`.
+
+* `--tls_ocsp_check_only_leaf_certificate=<true|false>` default `false`
+
+  This flag controls behavior of validator in cases when certificate chain contains more than two certificates (leaf + CA).
+  `true` will make validator only verify leaf certificate while `false` will make it check all certificates up to CA
+  (not including CA since it's already trusted).
+
+* `--tls_ocsp_client_url=""` default (empty)
+
+  OCSP service URL for incoming TLS connections to check client certificates.
+  Only available for `acra-server` where we have both client and server TLS connections.
+
+* `--tls_ocsp_database_url=""` default (empty)
+
+  OCSP service URL for outcoming TLS connections to check database certificates.
+  Only available for `acra-server` where we have both client and server TLS connections.
+
+* `--tls_ocsp_from_cert=<use|trust|prefer|ignore>` default `prefer`
+
+  How to treat OCSP server URL described in certificate itself
+
+  * `use`: try URL(s) from certificate after the one from configuration (if set)
+  * `trust`: try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer`: try URL(s) from certificate before the one from configuration (if set)
+  * `ignore`: completely ignore OCSP URL(s) specified in certificate
+
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags
+
+* `--tls_ocsp_required=<denyUnknown|allowUnknown|requireGood>` default `denyUnknown`
+
+  How to treat situation when OCSP server doesn't know about requested certificate and returns "Unknown"
+
+  `denyUnknown`: consider "Unknown" response an error, certificate validation will fail
+  `allowUnknown`: reverse of `denyUnknown`, allow certificates unknown to OCSP server
+  `requireGood`: require all known OCSP servers to respond "Good" in order to allow certificate and
+  continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+
+* `--tls_ocsp_url=""` default (empty)
+
+  OCSP service URL.
+
+  For `acra-server` it will work like `--tls_ocsp_client_url` and `--tls_ocsp_database_url`
+  passed simultaneously with same value.
+
+  For `acra-connector` and `acra-translator` (that can only work as TLS clients)
+  it will set OCSP URL for validation of certificates sent by server.


### PR DESCRIPTION
Documentation about:
* TLS flags for `acra-connector`, `acra-server`, `acra-translator`
  * Does not include Vault-related flags
  * Includes OCSP- and CRL-related flags
* Few `openssl`-related hints:
  * What to add in openssl configuration to make it include OCSP and/or CRL URL in signed certificates
  * How to launch `openssl ocsp` server
  * How to generate CRL
  * Dedicated page describing how certificates can be generated using `openssl` CLI tool

TLS page contains invalid link to PKI page at the bottom, I suppose it will be valid when corresponding page will be added.
Or do we need this link in navigation tree on the left? Dunno how to do it like that.