### PR TITLE
Describe acra-authmanager

### DIFF
--- a/acra/configuring-maintaining/general-configuration/acra-authmanager.md
+++ b/acra/configuring-maintaining/general-configuration/acra-authmanager.md
@@ -1,0 +1,131 @@
+---
+title: acra-authmanager
+bookCollapseSection: true
+---
+
+# acra-authmanager
+
+`acra-authmanager` is CLI utility for [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig.md) user management.
+Using this utility you can add/update/remove users that should have access to web UI of `acra-webconfig`. It changes 
+encrypted auth file that stores all users and hashed passwords for basic authentication.
+
+## Command line flags
+
+`acra-authamanager` should be called with same `ACRA_MASTER_KEY` that used for `acra-server`. Only these two binaries can
+read encrypted file with authentication data. 
+
+### Configuration files
+
+* `--file=<filepath>`
+  
+    Path to encrypted file where stored authentication data
+    Default is `configs/auth.keys`
+
+* `--user=<username>`
+
+    Name of user that will be added/removed/updated. This flag is required.
+  
+* `--password=<password>`
+
+    User's password that will be used for basic authentication. Cannot be empty for `--set` operation and unused for 
+    `--remove` operation.
+  
+* `--remove`
+  
+    Flag to remove user specified by `--user=<user>` flag. 
+  
+* `--set`
+
+    Flag to add/update password for user specified by `--user=<user>` flag. Password cannot be empty.
+
+### Configuration files
+
+* `--config_file=<filename>`
+
+  Path to YAML configuration file.
+
+* `--dump_config`
+
+  Dump configuration to `configs/acra-addzone.yaml`.
+
+* `--generate_markdown_args_table`
+
+  Generate markdown file with text description of all flags.
+  Output file is `configs/markdown_acra-addzone.md`.
+  Works in pair with `--dump_config`.
+
+### Logging
+
+* `-d`
+
+  Log to stderr all `DEBUG`, `INFO`, `WARNING` and `ERROR` logs.
+
+
+### Storage destination
+
+#### Filesystem
+
+* `--keys_dir=<path>`
+
+  Path to keystore directory.
+
+  Default is `.acrakeys`.
+
+### HashiCorp Vault
+
+`acra-authmanager` can read `ACRA_MASTER_KEY` from HashiCorp Vault instead of environment variable.
+
+* `--vault_connection_api_string=<url>`
+
+  Connection string (like `https://example.com:8200`) for connecting to HashiCorp Vault.
+  If not specified, `ACRA_MASTER_KEY` environment variable will be used.
+
+* `--vault_secrets_path=<kv-path>`
+
+  Path to KV Secrets directory in Vault used to store `ACRA_MASTER_KEY`.
+  Default is `secret/`.
+
+* `--vault_tls_ca_path=<path>`
+
+  Path to CA certificate bundle to use for HashiCorp Vault certificate validation.
+
+  If not specified, use root certificates configured in system.
+
+* `--vault_tls_client_cert=<path>`
+
+  Path to client TLS certificate used to connect to HashiCorp Vault.
+
+  If not specified, don't send client certificate.
+
+* `--vault_tls_client_key=<path>`
+
+  Path to the private key of the client TLS certificate used to connect to HashiCorp Vault.
+
+  If not specified, don't send client certificate.
+
+* `--vault_tls_transport_enable={true|false}`
+
+  Use TLS to encrypt transport with HashiCorp Vault.
+  Default is `false`.
+
+## Auth file
+
+`acra-authmanager` updates encrypted file where stored rows in format: 
+```
+<user>:<salt>:<hash_function_parameters>:<hash(salt, password, parameters)>
+<user>:<salt>:<hash_function_parameters>:<hash(salt, password, parameters)>
+<user>:<salt>:<hash_function_parameters>:<hash(salt, password, parameters)>
+``` 
+Each row is separate entry related to distinct user. 
+
+Every password hashed using [Argon2 hash function](https://en.wikipedia.org/wiki/Argon2). You can find current parameter
+values used for hash function in [Acra source code](https://github.com/cossacklabs/acra/blob/master/cmd/constants.go#L34).
+
+Example of decrypted auth file:
+```
+user1:teVSBZPexDCrhQyf:3,8192,2,32:s+5DGNl06ClB7tDoVyJbj3hnfPmEZzaL5SxcxV9dTDA=
+user2:pozbKtOLYWrHFQIG:3,8192,2,32:DubAhRrPEKbE1wCV2/yFt9mWL+W95JfCJAScoyZCMuI=
+```
+
+There are at first row `user1` is username, `teVSBZPexDCrhQyf` is salt, `3,8192,2,32` are parameters for Argon2 hash function 
+and `s+5DGNl06ClB7tDoVyJbj3hnfPmEZzaL5SxcxV9dTDA=` hash of password.

--- a/acra/configuring-maintaining/general-configuration/acra-authmanager.md
+++ b/acra/configuring-maintaining/general-configuration/acra-authmanager.md
@@ -5,7 +5,7 @@ bookCollapseSection: true
 
 # acra-authmanager
 
-`acra-authmanager` is CLI utility for [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig.md) user management.
+`acra-authmanager` is CLI utility for [acra-webconfig]({{< ref "/acra/configuring-maintaining/general-configuration/acra-webconfig.md" >}}) user management.
 Using this utility you can add/update/remove users that should have access to web UI of `acra-webconfig`. It changes 
 encrypted auth file that stores all users and hashed passwords for basic authentication.
 
@@ -119,7 +119,7 @@ read encrypted file with authentication data.
 Each row is separate entry related to distinct user. 
 
 Every password hashed using [Argon2 hash function](https://en.wikipedia.org/wiki/Argon2). You can find current parameter
-values used for hash function in [Acra source code](https://github.com/cossacklabs/acra/blob/master/cmd/constants.go#L34).
+values used for hash function in [Acra source code](https://github.com/cossacklabs/acra/blob/release/0.85.0/cmd/constants.go#L34).
 
 Example of decrypted auth file:
 ```

--- a/acra/security-controls/zones.md
+++ b/acra/security-controls/zones.md
@@ -178,5 +178,5 @@ Just like with the previous method, AcraServer will match the ZoneID in response
 
 ### More information about Zones
 
-* [Tuning Acra]({{< ref "/acra/configuring-maintaining/optimisations/#zones-INVALID" >}}): How Zones affect certain tuning strategies for increased performance and security.
+* [Tuning Acra]({{< ref "/acra/configuring-maintaining/optimizations/#zones-INVALID" >}}): How Zones affect certain tuning strategies for increased performance and security.
 * [Using Zones on client]({{< ref "/acra/guides/advanced-integrations/client-side-integration-with-acra-connector.md#client-side-with-zones" >}}): A practical How-To on using AcraWriter with Zones on application side.


### PR DESCRIPTION
There is CLI description for `acra-authmanager` with example of auth.file. Created empty file for `acra-webconfig` to refer to this page at this PR and not break hugo rendering. Content of that page will be overwritten by #78.