### PR TITLE
Security controls > Transport security

### DIFF
--- a/acra/configuring-maintaining/optimizations/tls_configuration.md
+++ b/acra/configuring-maintaining/optimizations/tls_configuration.md
@@ -35,6 +35,3 @@ Even though CRLs can be cached, at the time when cached item expired, it will be
 If OCSP/CRL validations are a bottleneck in performance, you can try to make them faster by:
 - providing OCSP/CRL servers in different locations close to clients;
 - making sure they are powerful enough to process big amount of requests
-
-But you can make them faster: provide OCSP/CRL servers in different locations close to clients,
-make sure they are powerful enough to process big amount of requests.

--- a/acra/configuring-maintaining/tls/_index.md
+++ b/acra/configuring-maintaining/tls/_index.md
@@ -8,7 +8,7 @@ bookCollapseSection: true
 ## CLI flags
 
 Flags related to TLS configuration can be found on page listing all flags of a binary:
-* [AcraConnector](/acra/configuring-maintaining/general-configuration/acra-connector-INVALID/#tls)
+* [AcraConnector](/acra/configuring-maintaining/general-configuration/acra-connector/#tls)
 * [AcraServer](/acra/configuring-maintaining/general-configuration/acra-server/#tls)
 * [AcraTranslator](/acra/configuring-maintaining/general-configuration/acra-translator/#tls)
 

--- a/acra/security-controls/transport-security/_index.md
+++ b/acra/security-controls/transport-security/_index.md
@@ -2,3 +2,17 @@
 title: Transport security
 bookCollapseSection: true
 ---
+
+# Transport security
+
+There are few ways to get encrypted channel between application and database:
+
+* [AcraConnector]({{< ref "acra/security-controls/transport-security/acra-connector.md" >}}),
+  a proxy that lives next to your application and securely forwards all requests to AcraServer or AcraTranslator.
+* Direct connection to AcraServer,
+  with [TLS enabled between app and AcraServer]({{< ref "acra/security-controls/transport-security/tls.md" >}})
+  responsible for secure transmission.
+* ["separate encryption"]({{< ref "acra/security-controls/transport-security/separate_encryption.md" >}})
+  where the app is responsible for encryption of data before it is sent to AcraServer.
+  As a result it would be impossible to decrypt the data even if
+  attacker can "remove" encryption layers like TLS and inspect transmitted data.

--- a/acra/security-controls/transport-security/acra-connector.md
+++ b/acra/security-controls/transport-security/acra-connector.md
@@ -13,7 +13,7 @@ The secure connection can be either Themis Secure Session (default) or TLS, depe
 Also, compared to TLS, the client identifier
 (text string that uniquely identifies client and affects which encryption keys will be used when processing this client requests)
 will be set by AcraConnector, not taken from client TLS certificate.
-Configuration flag for this behaveior is `--client_id`.
+Configuration flag for this behavior is `--client_id`.
 
 [Here]({{< ref "acra/configuring-maintaining/general-configuration/acra-connector.md" >}})
 you can read more about AcraConnector configuration.

--- a/acra/security-controls/transport-security/acra-connector.md
+++ b/acra/security-controls/transport-security/acra-connector.md
@@ -1,0 +1,21 @@
+---
+title: AcraConnector
+bookCollapseSection: true
+weight: 1
+---
+
+# AcraConnector
+
+AcraConnector is a "proxy" component that can work between application and AcraServer or AcraTranslator.
+It will create a secure connection to AcraServer or AcraTranslator and will listen for connections from the application on the other side.
+The secure connection can be either Themis Secure Session (default) or TLS, depending on configuration.
+
+Also, compared to TLS, the client identifier
+(text string that uniquely identifies client and affects which encryption keys will be used when processing this client requests)
+will be set by AcraConnector, not taken from client TLS certificate.
+Configuration flag for this behaveior is `--client_id`.
+
+[Here]({{< ref "acra/configuring-maintaining/general-configuration/acra-connector.md" >}})
+you can read more about AcraConnector configuration.
+We also got a [guide]({{< ref "acra/guides/advanced-integrations/client-side-integration-with-acra-connector.md" >}})
+describing what it is and how you can use it.

--- a/acra/security-controls/transport-security/separate_encryption.md
+++ b/acra/security-controls/transport-security/separate_encryption.md
@@ -1,0 +1,26 @@
+---
+title: Separate encryption [ENTERPRISE]
+bookCollapseSection: true
+weight: 3
+---
+
+# Separate encryption [ENTERPRISE]
+
+When you want to encrypt data right in the application before sending it anywhere, even though you got TLS for secure transmission.
+
+The usual flow of data when you store a secret looks like this:
+* application send unencrypted data to AcraServer (maybe with AcraConnector between them)
+* AcraServer encrypts the data and stores encrypted variant in database
+
+The path between application and AcraServer remains encrypted with a strong protocol like TLS,
+but the confidential data itself is not protected by any additional layer.
+
+One way to reach kind of end to end encryption between app and database is to use AcraWriter.
+This is one more piece of software that will encrypt sensitive data on client side, making it
+decryptable only by AcraServer, then AcraServer will then re-encrypt it before storing in database.
+Compared to other components, AcraWriter is a library rather than a separate service.
+It creates crypto containers of [the same format]({{< ref "acra/acra-in-depth/data-structures/_index.md#acrastruct" >}})
+that AcraServer uses, and data encrypted with AcraWriter can be written directly to database.
+
+[Here]({{< ref "acra/guides/advanced-integrations/client-side-integration-with-acra-connector.md#acrawriter" >}})
+is an example guide about using AcraWriter in combination with AcraConnector.

--- a/acra/security-controls/transport-security/separate_encryption.md
+++ b/acra/security-controls/transport-security/separate_encryption.md
@@ -1,10 +1,10 @@
 ---
-title: Separate encryption [ENTERPRISE]
+title: Separate encryption
 bookCollapseSection: true
 weight: 3
 ---
 
-# Separate encryption [ENTERPRISE]
+# Separate encryption
 
 When you want to encrypt data right in the application before sending it anywhere, even though you got TLS for secure transmission.
 

--- a/acra/security-controls/transport-security/tls.md
+++ b/acra/security-controls/transport-security/tls.md
@@ -1,0 +1,20 @@
+---
+title: TLS
+bookCollapseSection: true
+weight: 2
+---
+
+# TLS
+
+Acra services such as AcraServer and AcraTranslator support TLS connection from clients.
+In this case these services perform all the crypto operations and client/application only works with unencrypted data,
+making TLS the one that protects the data.
+
+Apart from the fact that the transport layer will be encrypted, TLS has another important role:
+client authentication and key selection.
+TLS certificate presented to AcraServer or AcraTranslator will prove that it's indeed a legitimate and known client.
+It will also give server side the identifier of encryption keys that should be used to process requests of this specific client.
+In other words, clients won't be able to decrypt each others data since they can only decrypt things encrypted with their own keys.
+
+More info about TLS configuration can be found [here]({{< ref "acra/configuring-maintaining/tls/_index.md" >}}).
+The part where client identifier is extracted from the certificate is controlled by `--tls_identifier_extractor_type` flag.


### PR DESCRIPTION
Fill pages that describe AcraConnector and TLS as transport encryption.
Mention AcraWriter that can encrypt data on client side. Not sure about its name (called _separate encryption_) though.

Fix few things noticed during docs exploration.