### PR TITLE
Fix merging issues that broke build

### DIFF
--- a/acra/acra-in-depth/cryptography-and-key-management/_index.md
+++ b/acra/acra-in-depth/cryptography-and-key-management/_index.md
@@ -53,7 +53,7 @@ of your choice (i.e. FIPS, GOST), [drop us an email](mailto:sales@cossacklabs.co
 ### TLS
 
 Acra handles TLS connections between: 
-* Application and [AcraServer]({{< ref "/acra/configuring-maintaining/general-configuration/acra-server.md" >}}). Used to protect plaintext from application to AcraServer in [Transparent encryption mode](/acra/configuring-maintaining/general-configuration/acra_server.md#transparent-encryption-mode-INVALID), and to 
+* Application and [AcraServer]({{< ref "/acra/configuring-maintaining/general-configuration/acra-server.md" >}}). Used to protect plaintext from application to AcraServer in [Transparent encryption mode](/acra/configuring-maintaining/general-configuration/acra-server.md#transparent-encryption-mode-INVALID), and to 
   protect decrypted plaintext by AcraServer before sending to application
   App <-> AcraServer.
 * AcraServer and database. Used to protect other data transmitted through AcraServer to database and to be transparent for 

--- a/acra/acra-in-depth/data-flow/_index.md
+++ b/acra/acra-in-depth/data-flow/_index.md
@@ -9,7 +9,7 @@ bookCollapseSection: true
 
 - [_AcraWriter_]({{< ref "/acra/configuring-maintaining/installing/building-acrawriter.md" >}}) — a client-side library that integrates into the app's workflow either through ORM or directly and provides the means for encryption of the sensitive data by generating AcraStructs.
 
-- [_AcraServer_]({{< ref "/acra/configuring-maintaining/general-configuration/acra_server.md" >}}) — a separate daemon that runs in an isolated environment (separate virtual machine or physical server). AcraServer is responsible for holding all the secrets required to decrypt the data and for actually decrypting this data.
+- [_AcraServer_]({{< ref "/acra/configuring-maintaining/general-configuration/acra-server.md" >}}) — a separate daemon that runs in an isolated environment (separate virtual machine or physical server). AcraServer is responsible for holding all the secrets required to decrypt the data and for actually decrypting this data.
 
 - [_AcraCensor_]({{< ref "/acra/security-controls/sql-firewall/" >}}) – is a firewall-like component that sits inside AcraServer, and checks every SQL query to the database.
 
@@ -19,7 +19,7 @@ bookCollapseSection: true
   
 Second way to protect raw data between application and AcraServer/AcraTranslator is to use AcraConnector:
 
-- [_AcraConnector_]({{< ref "/acra/configuring-maintaining/general-configuration/acra_connector.md" >}}) — a client-side daemon that runs under a separate user / in a separate container, and which acts as a database listener that redirects all the queries to AcraServer and, upon receiving the results, feeds it back into the app. AcraConnector is an optional component, required in systems that are using extra transport encryption layer via Themis SecureSession.
+- [_AcraConnector_]({{< ref "/acra/configuring-maintaining/general-configuration/acra-connector.md" >}}) — a client-side daemon that runs under a separate user / in a separate container, and which acts as a database listener that redirects all the queries to AcraServer and, upon receiving the results, feeds it back into the app. AcraConnector is an optional component, required in systems that are using extra transport encryption layer via Themis SecureSession.
 
   ![](/files/data-flow/acra-entities.png)    
   
@@ -48,7 +48,7 @@ With TLS as secure transport between application and AcraServer/AcraTranslator:
 
    **Description**: application sends data to database through AcraServer in [Transparent encryption mode](/acra/configuring-maintaining/general-configuration/acra-server/#transparent-proxy-mode-INVALID).
    All data manipulations like [encryption]({{< ref "/acra/security-controls/encryption/" >}})/
-   [tokenization]({{< ref "/acra/security-controls/tokenisation/" >}})/[masking]({{< ref "/acra/security-controls/masking/" >}})
+   [tokenization]({{< ref "/acra/security-controls/tokenization/" >}})/[masking]({{< ref "/acra/security-controls/masking/" >}})
    applied on AcraServer side before sending to database. 
 
    **Reading**: Database --> AcraServer --> Application.
@@ -91,7 +91,7 @@ With SecureSession and AcraConnector for secure transport:
 
    **Description**: application sends data to database through AcraServer in transparent encryption mode and AcraConnector.
    All data manipulations like [encryption]({{< ref "/acra/security-controls/encryption/" >}})/
-   [tokenization]({{< ref "/acra/security-controls/tokenisation/" >}})/[masking]({{< ref "/acra/security-controls/masking/" >}}) 
+   [tokenization]({{< ref "/acra/security-controls/tokenization/" >}})/[masking]({{< ref "/acra/security-controls/masking/" >}}) 
    applied on AcraServer side before sending to database. Raw data sent to AcraServer through AcraConnector that protect
    it using SecureSession.
 

--- a/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
+++ b/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
@@ -1,12 +1,12 @@
 ---
-title: AcraLogVerifier
+title: acra-log-verifier
 bookCollapseSection: true
 weight: 3
 ---
 
-# AcraLogVerifier
+# acra-log-verifier
 
-AcraLogVerifier is command-line utility that verifies secure logs dumped from AcraServer/AcraTranslator/AcraConnector started with `--audit_log_enable=true` flag.
+`acra-log-verifier` is command-line utility that verifies secure logs dumped from AcraServer/AcraTranslator/AcraConnector started with `--audit_log_enable=true` flag.
 
 It expects symmetric key to decrypt keys from keystore from  `ACRA_MASTER_KEY` environment variable in pair `--keys_dir` flag or from HashiCorp Vault together with `--vault_*` flags. 
 
@@ -264,7 +264,7 @@ ERRO[2021-09-02T01:03:31+03:00] Logs verification error                       er
 ```
 
 Verifier will exit with status 1.
-AcraLogVerifier allows run verification with `--audit_log_missing_ok` that will ignore such errors. It is useful in some 
+`acra-log-verifier` allows run verification with `--audit_log_missing_ok` that will ignore such errors. It is useful in some 
 cases of automation when file with list may be generated before finishing log collection of last service startup. And avoid
 legal verification failures of not finished last file.
 
@@ -272,7 +272,7 @@ legal verification failures of not finished last file.
 acra-log-verifier --audit_log_file_list=log_file_list.txt --audit_log_missing_ok
 ```
 
-AcraLogVerifier will just warn about missing file but finish with 0 status:
+`acra-log-verifier` will just warn about missing file but finish with 0 status:
 ```
 INFO[2021-09-02T01:13:23+03:00] Initializing ACRA_MASTER_KEY loader...       
 INFO[2021-09-02T01:13:23+03:00] Initialized default env ACRA_MASTER_KEY loader 

--- a/acra/security-controls/security-logging-and-events/secure_logging.md
+++ b/acra/security-controls/security-logging-and-events/secure_logging.md
@@ -5,13 +5,13 @@ bookCollapseSection: true
 
 ## Secure logging
 
-Acra supports secure and verifiable logging for [AcraServer]({{< ref "/acra/configuring-maintaining/general-configuration/acra_server.md" >}}), [AcraTranslator]({{< ref "/acra/configuring-maintaining/general-configuration/acra_translator.md" >}}) and [AcraConnector](({{< ref "/acra/configuring-maintaining/general-configuration/acra_connector.md" >}})).
+Acra supports secure and verifiable logging for [AcraServer]({{< ref "/acra/configuring-maintaining/general-configuration/acra-server.md" >}}), [AcraTranslator]({{< ref "/acra/configuring-maintaining/general-configuration/acra-translator.md" >}}) and [AcraConnector](({{< ref "/acra/configuring-maintaining/general-configuration/acra-connector.md" >}})).
 
 It is designed to prevent (mitigate) the possibility of making any adversarial changes in logs of mentioned services. Our design is based on state-of-the-art [scientific work](https://eprint.iacr.org/2008/185.pdf), where the two cryptographic schemes (based on symmetric / asymmetric keys) of secure logging functionality are described. 
 
 We have chosen a scheme that is based on symmetric keys according to the following reasons: 1) high performance; 2) simple and boring cryptographic design.
 
-Secure logging consists of two parts: **service** that produce secured logs (AcraServer, AcraTranslator and AcraConnector) and **verifier** ([acra-log-verifier]({{< ref "/acra/configuring-maintaining/general-configuration/acra_log_verifier.md" >}})) that checks and validates dump of logs.
+Secure logging consists of two parts: **service** that produce secured logs (AcraServer, AcraTranslator and AcraConnector) and **verifier** ([acra-log-verifier]({{< ref "/acra/configuring-maintaining/general-configuration/acra-log-verifier.md" >}})) that checks and validates dump of logs.
 
 ### What you will get with secure logging
 
@@ -59,10 +59,10 @@ The value of **IC[n]** depends on **LE[n]** and internal state, that is not pres
 
 ### How setup secure logging
 
-1. Generate symmetric key for **services** and `acra-log-verifier` by [acra-keymaker]({{< ref "/acra/configuring-maintaining/general-configuration/acra_keymaker.md" >}}) using flag `--generate_log_key`.
+1. Generate symmetric key for **services** and `acra-log-verifier` by [acra-keymaker]({{< ref "/acra/configuring-maintaining/general-configuration/acra-keymaker.md" >}}) using flag `--generate_log_key`.
 2. Run AcraServer/AcraTranslator/AcraConnector with the flag `--audit_log_enable=true` to turn on secure
    logging and save all output into some storage that may be dumped into file or just specify path to file with flag `--log_to_file=<path>` where services will save logs.
-3. Configure your environment to verify logs via [acra-log-verifier]({{< ref "/acra/configuring-maintaining/general-configuration/acra_log_verifier.md" >}}) before copying/archiving/backup to be sure that secure log is valid and finalized. 
+3. Configure your environment to verify logs via [acra-log-verifier]({{< ref "/acra/configuring-maintaining/general-configuration/acra-log-verifier.md" >}}) before copying/archiving/backup to be sure that secure log is valid and finalized. 
 4. Configure your alerting on any errors from `acra-log-verifier`. Verifier will finish with **non-zero** exit status on any validation errors.
 
 Common pattern in collecting logs is their rotation related with their size, row counts, time of life, etc. 


### PR DESCRIPTION
Fix merging that left `acra_server.md`/`acra_connector.md` usage and unified naming for `acra-log-verifier` page according to other pages.
Fixes T2051