### PR TITLE
Key storing v1

### DIFF
--- a/acra/acra-in-depth/architecture/api_service.md
+++ b/acra/acra-in-depth/architecture/api_service.md
@@ -1,5 +1,5 @@
 ---
-title: AcraTranslator: API service
+title: 'AcraTranslator: API service'
 bookCollapseSection: true
 weight: 3
 ---

--- a/acra/acra-in-depth/architecture/sql_proxy.md
+++ b/acra/acra-in-depth/architecture/sql_proxy.md
@@ -1,5 +1,5 @@
 ---
-title: AcraServer: SQL proxy
+title: 'AcraServer: SQL proxy'
 bookCollapseSection: true
 weight: 2
 ---

--- a/acra/configuring-maintaining/general-configuration/acra-server.md
+++ b/acra/configuring-maintaining/general-configuration/acra-server.md
@@ -400,7 +400,7 @@ weight: 3
   * `distinguished_name` — (default) certificate Distinguished Name (DN)
   * `serial_number` — certificate serial number
 
-### Vault
+### Hashicorp Vault
 
 * `--vault_connection_api_string=<url>`
 

--- a/acra/configuring-maintaining/key-storing/_index.md
+++ b/acra/configuring-maintaining/key-storing/_index.md
@@ -4,6 +4,43 @@ bookCollapseSection: true
 weight: 1
 ---
 
-**TODO: Expand**
-
 # Key management and key storage in general 
+
+Key management with key storage is core component of Acra responsible for security guarantees. The whole cryptography 
+used in Acra depends on key storage. Without great key management, even strong and correctly used cryptography can't 
+guarantee safety for data.
+
+Key management is a set of approaches and processes related to key storing, rotation, distribution, protection, 
+compartmentalization. Acra provides tools and pushes the processes in key management in the secure way to cover all 
+aspects of keys security and help to reach compliance in data security.
+
+## Keys protection
+
+Every private key that stored and used by Acra encrypted with [Secure Cell]({{< ref "/themis/crypto-theory/cryptosystems/secure-cell.md" >}})
+that designed and responsible for secure storage. To encrypt all private keys Acra needs master key for symmetric cryptography
+under the hood of Secure Cell. This master key may be passed to Acra in two ways:
+* environment variable
+* KMS
+  Passing master key via environment variable as simple as possible. You can find example on our page
+  [Necessary preparations]({{< ref "/acra/configuring-maintaining/general-configuration/necessary_prep.md" >}}).
+
+KMS has a lot of implementations and providers. You can find which of them Acra supports on our
+[KMS integration]({{< ref "/acra/configuring-maintaining/key-storing/kms.md" >}}) page.
+
+## Key storage
+
+Acra relies on a lot of keys that generated per user, per purposes. Also, they may be rotated and at the same time
+may exist several keys for same purpose. This set of keys should be somewhere stored and support distributed access
+to provide high performance and scalability. Acra supports several storages that may be used for key storage.
+[Read more]({{< ref "/acra/configuring-maintaining/key-storing/kv-stores.md" >}}) about supported key storages.
+
+
+## Key management
+
+About tools related to key generation, rotation, backup you can read on our page about 
+[key management]({{< ref "acra/keys/_index.md" >}}) with describing related tools.
+
+## Compartmentalization
+
+Acra uses distinct keys for each purpose and in such way provide compartmentalization of keys duty. 
+More about it you can find on our [Inventory of Acra keys]({{< ref "/acra/keys/inventory.md" >}}) page.

--- a/acra/configuring-maintaining/key-storing/_index.md
+++ b/acra/configuring-maintaining/key-storing/_index.md
@@ -4,7 +4,7 @@ bookCollapseSection: true
 weight: 1
 ---
 
-# Key management and key storage in general 
+# Key management and key storage
 
 Key management with key storage is core component of Acra responsible for security guarantees. The whole cryptography 
 used in Acra depends on key storage. Without great key management, even strong and correctly used cryptography can't 

--- a/acra/configuring-maintaining/key-storing/kms.md
+++ b/acra/configuring-maintaining/key-storing/kms.md
@@ -16,7 +16,15 @@ guarantees.
 
 [Hashicorp Vault](https://www.vaultproject.io/) is popular, widely used service for secure storing sensitive data, 
 especially secrets. Acra uses Hashicorp Vault as storage for master key used to encrypt/decrypt all private keys.
-Every Acra service that operates with key storage (`acra-server`, `acra-translator`, `acra-keymaker`, `acra-rotate`, etc)
+Every Acra service that operates with key storage (
+[acra-server]({{< ref "/acra/configuring-maintaining/general-configuration/acra-server.md#hashicorp-vault" >}}), 
+[acra-translator]({{< ref "/acra/configuring-maintaining/general-configuration/acra-translator.md#hashicorp-vault" >}}), 
+[acra-keymaker]({{< ref "/acra/configuring-maintaining/general-configuration/acra-keymaker.md#hashicorp-vault" >}}), 
+[acra-rotate]({{< ref "/acra/configuring-maintaining/general-configuration/acra-rotate.md#hashicorp-vault" >}}), [acra-addzone]({{< ref "/acra/configuring-maintaining/general-configuration/acra-addzone.md#hashicorp-vault" >}}),
+[acra-backup]({{< ref "/acra/configuring-maintaining/general-configuration/acra-backup.md#hashicorp-vault" >}}),
+[acra-log-verifier]({{< ref "/acra/configuring-maintaining/general-configuration/acra-log-verifier.md#hashicorp-vault" >}}),
+[acra-poisonrecordmaker]({{< ref "/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md#hashicorp-vault" >}}),
+[acra-rollback]({{< ref "/acra/configuring-maintaining/general-configuration/acra-rollback.md#hashicorp-vault" >}}))
 can load master key from this KMS. You can find out how to configure access to KMS on `HashiCorp Vault` section on the 
 distinct documentation page of these services.
 

--- a/acra/configuring-maintaining/key-storing/kms.md
+++ b/acra/configuring-maintaining/key-storing/kms.md
@@ -1,11 +1,31 @@
-
+---
 title: KMS integration
 bookCollapseSection: true
 weight: 2
 ---
 
-**TODO: Expand**
+# KMS integration
 
-# Which KMS we support
+KMS is important part of keys security. For now Acra uses KMS to load master key used to encrypt and decrypt private keys.
+Safety of master key is important guarantee of keys protection. So Acra has strong requirements to KMS and their security
+guarantees.
 
-# How we support it 
+## Which KMS we support
+
+### Hashicorp Vault
+
+[Hashicorp Vault](https://www.vaultproject.io/) is popular, widely used service for secure storing sensitive data, 
+especially secrets. Acra uses Hashicorp Vault as storage for master key used to encrypt/decrypt all private keys.
+Every Acra service that operates with key storage (`acra-server`, `acra-translator`, `acra-keymaker`, `acra-rotate`, etc)
+can load master key from this KMS. You can find out how to configure access to KMS on `HashiCorp Vault` section on the 
+distinct documentation page of these services.
+
+Hashicorp Vault supports a lot of storage backends, that guarantee high availability, scalability, authenticated and 
+secure transport communication. That is why Acra supports is out of the box.
+
+## How we support it 
+
+On startup every tool or daemon that needs access to private keys loads master key from KMS. They load and store it in 
+memory and use to decrypt private key every time. After using private key services forget and erase private keys from memory
+to leave them in unprotected form as less as possible. Only master key loaded from KMS gives Acra access to private keys
+and sensitive data protected with these keys.

--- a/acra/configuring-maintaining/key-storing/kv-stores.md
+++ b/acra/configuring-maintaining/key-storing/kv-stores.md
@@ -1,4 +1,3 @@
-
 title: Scalable KV storages
 bookCollapseSection: true
 weight: 2

--- a/acra/security-controls/transport-security/acra-connector.md
+++ b/acra/security-controls/transport-security/acra-connector.md
@@ -1,6 +1,4 @@
 ---
-
-=======
 title: AcraConnector
 bookCollapseSection: true
 weight: 1


### PR DESCRIPTION
There is the first version of the content for KMS and key-storing pages.
I'm not sure how we want to describe our KMS support, probably somehow tell that we can extend KMS integrations after buying an enterprise license.
I didn't start to write content for `kv-stores.md` with description of supported storages because I'm not sure that I can finish. Plus we should decide, do we want to describe there about all storages that we support or only keys related. Because we don't support boltdb and in-memory (only in-memory cache) storages for keys, only for tokens.