### PR TITLE
Note that OpenSSL 3.0 is not yet supported by Themis

### DIFF
--- a/themis/installation/installation-from-sources.md
+++ b/themis/installation/installation-from-sources.md
@@ -182,6 +182,12 @@ the one that includes both the engine binaries and its header files.
 The package is usually called `libssl-dev` or `openssl-devel`.
 {{< /hint >}}
 
+#### OpenSSL
+
+OpenSSL is the default cryptographic engine on most platforms.
+Themis will automatically detect and use OpenSSL installed in your system.
+If you wish to explicitly require OpenSSL, set `ENGINE=openssl` when building Themis.
+
 #### BoringSSL
 
 You can opt for BoringSSL by setting `ENGINE=boringssl`.

--- a/themis/installation/installation-from-sources.md
+++ b/themis/installation/installation-from-sources.md
@@ -37,6 +37,15 @@ as it contains the necessary header files.
 
 In either case, we **strongly** recommend that you use the most recent version of these packages.
 
+{{< hint warning >}}
+**Note:**
+At the moment Themis is not fully compatible with OpenSSL 3.0.
+Please use the latest OpenSSL 1.1.1 unless you know what you are doing.
+Rest assured, OpenSSL 1.1.1 is getting security updates at least until September 2023.
+
+Status of Themis migration to OpenSSL 3.0 can be tracked [on GitHub](https://github.com/cossacklabs/themis/issues/873).
+{{< /hint >}}
+
 ### Building with Make
 
 Start with getting the latest Themis source code from GitHub:

--- a/themis/installation/installation-from-sources.md
+++ b/themis/installation/installation-from-sources.md
@@ -163,7 +163,7 @@ make all WITH_ASAN=yes
 
 Currently, Themis supports OpenSSL-like cryptographic engines (libcrypto):
 
-  - [OpenSSL](https://www.openssl.org/)
+  - [OpenSSL](https://www.openssl.org/) (1.1)
   - [LibreSSL](http://www.libressl.org/)
   - [BoringSSL](https://boringssl.googlesource.com/boringssl/)
 
@@ -196,6 +196,12 @@ The package is usually called `libssl-dev` or `openssl-devel`.
 OpenSSL is the default cryptographic engine on most platforms.
 Themis will automatically detect and use OpenSSL installed in your system.
 If you wish to explicitly require OpenSSL, set `ENGINE=openssl` when building Themis.
+
+{{< hint warning >}}
+**Note:**
+At the moment Themis supports only OpenSSL 1.0.2 and 1.1.x branches.
+OpenSSL 3.0 is still not fully supported.
+{{< /hint >}}
 
 #### BoringSSL
 


### PR DESCRIPTION
Put a warning right at the top of the page, making it explicit that we don't support OpenSSL 3.0 at the moment, but are actively working on making the transition happen.

This only concerns those who build Themis manually from source. For packages, we will make sure that Themis depends on OpenSSL 1.1 until it's ready to depend on OpenSSL 3.0, and then switch over automagically.