### PR TITLE
Mark required flags

### DIFF
--- a/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -111,7 +111,8 @@ INFO[0000] Initialized default env ACRA_MASTER_KEY loader
 Currently, only some key kinds are supported for destroying via `destroy` subcommand.
 Here is the list of supported key kinds:
 
-- `transport-connector`
-- `transport-server`
-- `transport-translator`
-  {{< /hint >}}
+<!-- cmd/acra-keys/keys/command-line.go func ParseKeyKind -->
+- `client/<client ID>/transport/connector`
+- `client/<client ID>/transport/server`
+- `client/<client ID>/transport/translator`
+{{< /hint >}}

--- a/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -11,7 +11,7 @@ weight: 2
 
 ### General flags
 
-* `--client_id=<id>`
+* `--client_id=<id>` 🔴
 
   Use provided ClientID as identifier to generate keys or keypairs.
 
@@ -28,7 +28,7 @@ weight: 2
 
   By default, certificate `distinguished_name` is used as ClientID.
 
-* `--keystore=<v1|v2>`
+* `--keystore=<v1|v2>` 🔴
 
   Set keystore format.
   Read more about [keystore versions]({{< ref "/acra/security-controls/key-management/versions/" >}}).
@@ -192,3 +192,7 @@ while the previous key is archived and used only for decryption.
 * `--zone_id`
 
   Zone ID should be used for `zone_storage_key` generating.
+
+
+  🔴 - flags required to be specified.
+  > Exception: `--client_id` is not required when generating only poison record keys

--- a/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -101,7 +101,7 @@ Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v2`.
 {{< /hint >}}
 
 ```
-$ acra_keys generate --client_id=user1 --keystore=v2 --client_storage_key
+$ acra-keys generate --client_id=user1 --keystore=v2 --client_storage_key
 
 INFO[0000] Initializing ACRA_MASTER_KEY loader...       
 INFO[0000] Initialized default env ACRA_MASTER_KEY loader 
@@ -125,10 +125,8 @@ INFO[0000] Initialized default env ACRA_MASTER_KEY loader
 Currently, only some key kinds are supported for printing via `read` subcommand.
 Here is the list of supported key kinds:
 
-- `poison-public` 
-- `poison-private`
-- `storage-public`
-- `storage-private`
-- `zone-public`
-- `zone-private`
+<!-- cmd/acra-keys/keys/command-line.go func ParseKeyKind -->
+- `poison-record` public, private
+- `client/<client ID>/storage` public, private
+- `zone/<zone ID>/storage` public, private
 {{< /hint >}}

--- a/acra/configuring-maintaining/general-configuration/acra-server.md
+++ b/acra/configuring-maintaining/general-configuration/acra-server.md
@@ -224,7 +224,7 @@ weight: 3
 
 ### Network
 
-* `--db_host=<host>`
+* `--db_host=<host>` 🔴
 
   Database host for AcraServer → database connections.
   Must be set.
@@ -435,6 +435,8 @@ For additional certificate validation flags, see corresponding pages:
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
 
+
+  🔴 - flags required to be specified.
 
 ## HTTP API
 


### PR DESCRIPTION
Put big red dot next to required flags.
Also, make key kinds more clear in `acra-keys` subcommands.