### PR TITLE
Mark deprecated all mentions of authmanager and webconfig

### DIFF
--- a/acra/acra-in-depth/architecture/_index.md
+++ b/acra/acra-in-depth/architecture/_index.md
@@ -51,7 +51,7 @@ Acra consists of several services and utilities. Depending on your architecture 
 
 ### Additional useful tooling
 
-* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) — a lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
+* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) — a lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
 
 * [AcraConnector](/acra/security-controls/transport-security/acra-connector) — additional client-side service/daemon that implements transport security and authentication for client application that doesn't support TLS 1.2+. Connects client app with AcraServer/AcraTranslator.
 

--- a/acra/acra-in-depth/architecture/_index.md
+++ b/acra/acra-in-depth/architecture/_index.md
@@ -51,7 +51,7 @@ Acra consists of several services and utilities. Depending on your architecture 
 
 ### Additional useful tooling
 
-* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) — a lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
+* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated since 0.91.0) — a lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
 
 * [AcraConnector](/acra/security-controls/transport-security/acra-connector) — additional client-side service/daemon that implements transport security and authentication for client application that doesn't support TLS 1.2+. Connects client app with AcraServer/AcraTranslator.
 

--- a/acra/acra-in-depth/architecture/acraserver.md
+++ b/acra/acra-in-depth/architecture/acraserver.md
@@ -41,7 +41,7 @@ Your application doesn't need to handle any cryptographic code or have access to
 
 * Is easy to integrate into existing infrastructure – supports SQL databases, [supports SIEMs](/acra/security-controls/security-logging-and-events/siem-soc-integration/), [supports KMS](/acra/configuring-maintaining/key-storing/kms-integration/).
 * Is available as a package for common server Linux distros, available as Docker image. See [Getting started](/acra/getting-started/).
-* Is integrated with [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) - a helper tool for re-configuring at runtime.
+* Is integrated with [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated since 0.91.0) - a helper tool for re-configuring at runtime.
 * Supports a whole set of additional modules and tools - [key management](/acra/security-controls/key-management/), [SQL firewall](/acra/security-controls/sql-firewall), [AcraConnector](/acra/security-controls/transport-security/acra-connector) for better transport encryption, [AcraWriter](/acra/acra-in-depth/architecture/sdks/acrawriter/) for client-side encryption, [cryptographically-signed audit logs](/acra/security-controls/security-logging-and-events/audit-logging/).
 
 
@@ -74,7 +74,7 @@ Other connections are optional – for example, you can use Redis as external ke
 
 * [AcraConnector](/acra/security-controls/transport-security/acra-connector) – optional client-side service/daemon that implements transport security and authentication for client application that doesn't support TLS 1.2+.
 
-* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) — optional lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
+* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated since 0.91.0) — optional lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
 
 ## Architectural considerations
 

--- a/acra/acra-in-depth/architecture/acraserver.md
+++ b/acra/acra-in-depth/architecture/acraserver.md
@@ -41,7 +41,7 @@ Your application doesn't need to handle any cryptographic code or have access to
 
 * Is easy to integrate into existing infrastructure – supports SQL databases, [supports SIEMs](/acra/security-controls/security-logging-and-events/siem-soc-integration/), [supports KMS](/acra/configuring-maintaining/key-storing/kms-integration/).
 * Is available as a package for common server Linux distros, available as Docker image. See [Getting started](/acra/getting-started/).
-* Is integrated with [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) - a helper tool for re-configuring at runtime.
+* Is integrated with [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) - a helper tool for re-configuring at runtime.
 * Supports a whole set of additional modules and tools - [key management](/acra/security-controls/key-management/), [SQL firewall](/acra/security-controls/sql-firewall), [AcraConnector](/acra/security-controls/transport-security/acra-connector) for better transport encryption, [AcraWriter](/acra/acra-in-depth/architecture/sdks/acrawriter/) for client-side encryption, [cryptographically-signed audit logs](/acra/security-controls/security-logging-and-events/audit-logging/).
 
 
@@ -74,7 +74,7 @@ Other connections are optional – for example, you can use Redis as external ke
 
 * [AcraConnector](/acra/security-controls/transport-security/acra-connector) – optional client-side service/daemon that implements transport security and authentication for client application that doesn't support TLS 1.2+.
 
-* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) — optional lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
+* [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) — optional lightweight HTTP web server for managing AcraServer's certain configuration options at runtime by clicking rather than updating configuration files manually.
 
 ## Architectural considerations
 

--- a/acra/acra-in-depth/authentication/_index.md
+++ b/acra/acra-in-depth/authentication/_index.md
@@ -71,6 +71,10 @@ Read more about connection configuration to [popular KMS](/acra/configuring-main
 
 ## Privileged operations
 
+{{< hint warning >}}
+It is deprecated and will not be available after 0.90.0.
+{{< /hint >}}
+
 AcraServer supports changing configuration in runtime using [AcraWebConfig's](/acra/configuring-maintaining/general-configuration/acra-webconfig). AcraWebConfig is a simple web UI service that requires HTTP basic authentication.
 
 Privileged operations (changing configuration of AcraServer, restarting it) are available only for authenticated and authorized users. You should add users first using [acra-authmanager](/acra/configuring-maintaining/general-configuration/acra-authmanager) utility, then use these users' credentials to access AcraWebConfig.

--- a/acra/acra-in-depth/authentication/_index.md
+++ b/acra/acra-in-depth/authentication/_index.md
@@ -72,7 +72,7 @@ Read more about connection configuration to [popular KMS](/acra/configuring-main
 ## Privileged operations
 
 {{< hint warning >}}
-It is deprecated and will not be available after 0.90.0.
+AcraWebConfig tool is deprecated and will not be available since 0.91.0.
 {{< /hint >}}
 
 AcraServer supports changing configuration in runtime using [AcraWebConfig's](/acra/configuring-maintaining/general-configuration/acra-webconfig). AcraWebConfig is a simple web UI service that requires HTTP basic authentication.

--- a/acra/acra-in-depth/cryptography-and-key-management/_index.md
+++ b/acra/acra-in-depth/cryptography-and-key-management/_index.md
@@ -13,7 +13,7 @@ Cryptography is widely used across all Acra services for:
 * transport protection and authentication: during mutual authentication and encryption used in 
   [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/) and [TLS](/acra/configuring-maintaining/tls/);
 * [audit logging](/acra/security-controls/security-logging-and-events/audit-logging/): when calculating integrity checks of log messages and log chains;
-* [password hashing](/acra/configuring-maintaining/general-configuration/acra-authmanager#auth-file) of registered users of Acra Web Configuration UI (deprecated and removed after 0.90.0);
+* [password hashing](/acra/configuring-maintaining/general-configuration/acra-authmanager#auth-file) of registered users of Acra Web Configuration UI (deprecated and removed since 0.91.0);
 * [key management](/acra/security-controls/key-management/): all intermediate keys are encrypted by key encryption keys and Acra Master Key.
 
 
@@ -99,7 +99,7 @@ Additionally, Acra's services accept only TLS 1.2+ connections and cipher suites
 ### Password hashing
 
 {{< hint warning >}}
-Deprecated and will not in use after 0.90.0.
+AcraWebConfig tool is deprecated and removed since 0.91.0. After 0.91.0, Acra components don't store any accounts, thus, don't use password hashing.
 {{< /hint >}}
 
 [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig) web UI supports basic authentication for users. Users' passwords are hashed and stored in the [auth file](/acra/configuring-maintaining/general-configuration/acra-authmanager#auth-file).

--- a/acra/acra-in-depth/cryptography-and-key-management/_index.md
+++ b/acra/acra-in-depth/cryptography-and-key-management/_index.md
@@ -13,7 +13,7 @@ Cryptography is widely used across all Acra services for:
 * transport protection and authentication: during mutual authentication and encryption used in 
   [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/) and [TLS](/acra/configuring-maintaining/tls/);
 * [audit logging](/acra/security-controls/security-logging-and-events/audit-logging/): when calculating integrity checks of log messages and log chains;
-* [password hashing](/acra/configuring-maintaining/general-configuration/acra-authmanager#auth-file) of registered users of Acra Web Configuration UI;
+* [password hashing](/acra/configuring-maintaining/general-configuration/acra-authmanager#auth-file) of registered users of Acra Web Configuration UI (deprecated and removed after 0.90.0);
 * [key management](/acra/security-controls/key-management/): all intermediate keys are encrypted by key encryption keys and Acra Master Key.
 
 
@@ -97,6 +97,10 @@ Additionally, Acra's services accept only TLS 1.2+ connections and cipher suites
 
 
 ### Password hashing
+
+{{< hint warning >}}
+Deprecated and will not in use after 0.90.0.
+{{< /hint >}}
 
 [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig) web UI supports basic authentication for users. Users' passwords are hashed and stored in the [auth file](/acra/configuring-maintaining/general-configuration/acra-authmanager#auth-file).
 

--- a/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
+++ b/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
@@ -8,7 +8,7 @@ weight: 12
 ## Verbose logging
 
 In order to get more logs from AcraConnector, AcraServer or AcraTranslator, you can add `-v` (or even `-d`) flags to their configuration.
-You can also switch `-d` flag in running AcraServer using [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0).
+You can also switch `-d` flag in running AcraServer using [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated since 0.91.0).
 
 A lot of things may become clear:
 * wrong hosts/ports in configuration

--- a/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
+++ b/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
@@ -8,7 +8,7 @@ weight: 12
 ## Verbose logging
 
 In order to get more logs from AcraConnector, AcraServer or AcraTranslator, you can add `-v` (or even `-d`) flags to their configuration.
-You can also switch `-d` flag in running AcraServer using [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/).
+You can also switch `-d` flag in running AcraServer using [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0).
 
 A lot of things may become clear:
 * wrong hosts/ports in configuration

--- a/acra/configuring-maintaining/general-configuration/_index.md
+++ b/acra/configuring-maintaining/general-configuration/_index.md
@@ -17,7 +17,7 @@ Acra contains a set of special CLI utilities and services for specialized use ca
 
 * [`acra-translator`](/acra/configuring-maintaining/general-configuration/acra-translator/) - provides Acra's [security controls](/acra/security-controls/) via HTTP / gRPC API for client-side apps. Also offers client-side SDKs for easier integration
 
-* [`acra-webconfig`](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) - provides web UI for AcraServer's runtime configuration
+* [`acra-webconfig`](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated since 0.91.0) - provides web UI for AcraServer's runtime configuration
 
 
 ## Utilities
@@ -31,7 +31,7 @@ Acra contains a set of special CLI utilities and services for specialized use ca
 * [`acra-addzone`](/acra/configuring-maintaining/general-configuration/acra-addzone/)
   - is used for generating new [Zone keys](/acra/security-controls/zones/) for AcraBlocks/AcraStructs
 
-* [`acra-authmanager`](/acra/configuring-maintaining/general-configuration/acra-authmanager/) (deprecated after 0.90.0)
+* [`acra-authmanager`](/acra/configuring-maintaining/general-configuration/acra-authmanager/) (deprecated since 0.91.0)
   - is used for [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) user management.
 
 * [`acra-backup`](/acra/configuring-maintaining/general-configuration/acra-backup/)

--- a/acra/configuring-maintaining/general-configuration/_index.md
+++ b/acra/configuring-maintaining/general-configuration/_index.md
@@ -17,7 +17,7 @@ Acra contains a set of special CLI utilities and services for specialized use ca
 
 * [`acra-translator`](/acra/configuring-maintaining/general-configuration/acra-translator/) - provides Acra's [security controls](/acra/security-controls/) via HTTP / gRPC API for client-side apps. Also offers client-side SDKs for easier integration
 
-* [`acra-webconfig`](/acra/configuring-maintaining/general-configuration/acra-webconfig/) - provides web UI for AcraServer's runtime configuration
+* [`acra-webconfig`](/acra/configuring-maintaining/general-configuration/acra-webconfig/) (deprecated after 0.90.0) - provides web UI for AcraServer's runtime configuration
 
 
 ## Utilities
@@ -31,7 +31,7 @@ Acra contains a set of special CLI utilities and services for specialized use ca
 * [`acra-addzone`](/acra/configuring-maintaining/general-configuration/acra-addzone/)
   - is used for generating new [Zone keys](/acra/security-controls/zones/) for AcraBlocks/AcraStructs
 
-* [`acra-authmanager`](/acra/configuring-maintaining/general-configuration/acra-authmanager/)
+* [`acra-authmanager`](/acra/configuring-maintaining/general-configuration/acra-authmanager/) (deprecated after 0.90.0)
   - is used for [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) user management.
 
 * [`acra-backup`](/acra/configuring-maintaining/general-configuration/acra-backup/)

--- a/acra/configuring-maintaining/general-configuration/acra-authmanager.md
+++ b/acra/configuring-maintaining/general-configuration/acra-authmanager.md
@@ -3,7 +3,7 @@ title: acra-authmanager
 weight: 14
 ---
 
-# acra-authmanager (deprecated after 0.90.0)
+# acra-authmanager (deprecated since 0.91.0)
 
 `acra-authmanager` is CLI utility for [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) user management.
 Using this utility you can add/update/remove users that should have access to web UI of `acra-webconfig`. It changes 

--- a/acra/configuring-maintaining/general-configuration/acra-authmanager.md
+++ b/acra/configuring-maintaining/general-configuration/acra-authmanager.md
@@ -3,7 +3,7 @@ title: acra-authmanager
 weight: 14
 ---
 
-# acra-authmanager
+# acra-authmanager (deprecated after 0.90.0)
 
 `acra-authmanager` is CLI utility for [acra-webconfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) user management.
 Using this utility you can add/update/remove users that should have access to web UI of `acra-webconfig`. It changes 

--- a/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -193,6 +193,10 @@ while the previous key is archived and used only for decryption.
   
 ### AcraServer & AcraAuthManager keys
 
+{{< hint warning >}}
+It is deprecated and will not be available after 0.90.0.
+{{< /hint >}}
+
 * `--generate_acrawebconfig_keys`
   
   Generate a new symmetric key for encrypting AcraWebconfig's basic authentication credentials.

--- a/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -194,7 +194,7 @@ while the previous key is archived and used only for decryption.
 ### AcraServer & AcraAuthManager keys
 
 {{< hint warning >}}
-It is deprecated and will not be available after 0.90.0.
+AcraAuthManager tool is deprecated and will not be available since 0.91.0.
 {{< /hint >}}
 
 * `--generate_acrawebconfig_keys`

--- a/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -173,7 +173,7 @@ while the previous key is archived and used only for decryption.
 ### AcraServer & AcraAuthManager keys
 
 {{< hint warning >}}
-It is deprecated and will not be used after 0.90.0.
+AcraAuthManager tool is deprecated and will not be available since 0.91.0.
 {{< /hint >}}
 
 * `--acrawebconfig_symmetric_key`

--- a/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -172,6 +172,10 @@ while the previous key is archived and used only for decryption.
 
 ### AcraServer & AcraAuthManager keys
 
+{{< hint warning >}}
+It is deprecated and will not be used after 0.90.0.
+{{< /hint >}}
+
 * `--acrawebconfig_symmetric_key`
 
   Generate a new symmetric key for encrypting AcraWebconfig's basic authentication credentials.

--- a/acra/configuring-maintaining/general-configuration/acra-server.md
+++ b/acra/configuring-maintaining/general-configuration/acra-server.md
@@ -444,7 +444,7 @@ AcraServer handles HTTP requests that may change its internal state, generates n
 related with authentication of AcraWebConfig users.
 
 {{< hint warning >}}
-AcraWebConfig and AcraAuthManager are deprecated and will not be available after 0.90.0.
+AcraWebConfig and AcraAuthManager are deprecated and will not be available since 0.91.0.
 {{< /hint >}}
 
 {{< hint warning >}}
@@ -475,7 +475,7 @@ AcraServer supports only HTTP/1.1 requests without keep-alive.
   incorrect request
   ```
 
-- Endpoint: `/loadAuthData` (deprecated after 0.90.0).
+- Endpoint: `/loadAuthData` (deprecated since 0.91.0).
   Description: returns decrypted authentication data as pairs `<username>:<hash>` for AcraWebConfig. By default, encrypted
   data is stored in `configs/auth.keys` file in `htpasswd` format where each row is actually an entry related to separate user.
   Response type: text.
@@ -491,7 +491,7 @@ AcraServer supports only HTTP/1.1 requests without keep-alive.
   incorrect request
   ```
 
-- Endpoint: `/getConfig` (deprecated after 0.90.0).
+- Endpoint: `/getConfig` (deprecated since 0.91.0).
   Description: returns current AcraServer's configuration used while startup (maybe changed via AcraWebConfig).
   Response type: JSON object.
   Response example:
@@ -513,7 +513,7 @@ AcraServer supports only HTTP/1.1 requests without keep-alive.
   incorrect request
   ```
 
-- Endpoint: `/setConfig` (deprecated after 0.90.0).
+- Endpoint: `/setConfig` (deprecated since 0.91.0).
   Description: sets new configuration for AcraServer, dumps new configuration to config file specified from CLI flags
   or in config file (with default path) and gracefully restarts AcraServer's instance.
   Response type: empty.

--- a/acra/configuring-maintaining/general-configuration/acra-server.md
+++ b/acra/configuring-maintaining/general-configuration/acra-server.md
@@ -444,6 +444,10 @@ AcraServer handles HTTP requests that may change its internal state, generates n
 related with authentication of AcraWebConfig users.
 
 {{< hint warning >}}
+AcraWebConfig and AcraAuthManager are deprecated and will not be available after 0.90.0.
+{{< /hint >}}
+
+{{< hint warning >}}
 AcraServer supports only HTTP/1.1 requests without keep-alive.
 {{< /hint >}}
 
@@ -471,7 +475,7 @@ AcraServer supports only HTTP/1.1 requests without keep-alive.
   incorrect request
   ```
 
-- Endpoint: `/loadAuthData`.
+- Endpoint: `/loadAuthData` (deprecated after 0.90.0).
   Description: returns decrypted authentication data as pairs `<username>:<hash>` for AcraWebConfig. By default, encrypted
   data is stored in `configs/auth.keys` file in `htpasswd` format where each row is actually an entry related to separate user.
   Response type: text.
@@ -487,7 +491,7 @@ AcraServer supports only HTTP/1.1 requests without keep-alive.
   incorrect request
   ```
 
-- Endpoint: `/getConfig`.
+- Endpoint: `/getConfig` (deprecated after 0.90.0).
   Description: returns current AcraServer's configuration used while startup (maybe changed via AcraWebConfig).
   Response type: JSON object.
   Response example:
@@ -509,7 +513,7 @@ AcraServer supports only HTTP/1.1 requests without keep-alive.
   incorrect request
   ```
 
-- Endpoint: `/setConfig`.
+- Endpoint: `/setConfig` (deprecated after 0.90.0).
   Description: sets new configuration for AcraServer, dumps new configuration to config file specified from CLI flags
   or in config file (with default path) and gracefully restarts AcraServer's instance.
   Response type: empty.

--- a/acra/configuring-maintaining/general-configuration/acra-webconfig.md
+++ b/acra/configuring-maintaining/general-configuration/acra-webconfig.md
@@ -3,7 +3,7 @@ title: acra-webconfig
 weight: 15
 ---
 
-# acra-webconfig (deprecated after 0.90.0)
+# acra-webconfig (deprecated since 0.91.0)
 
 `acra-webconfig` is a simple web application that provides web UI for AcraServer's runtime configuration.
 You can adjust the following parameters of AcraServer via `acra-webconfig`:

--- a/acra/configuring-maintaining/general-configuration/acra-webconfig.md
+++ b/acra/configuring-maintaining/general-configuration/acra-webconfig.md
@@ -3,7 +3,7 @@ title: acra-webconfig
 weight: 15
 ---
 
-# acra-webconfig
+# acra-webconfig (deprecated after 0.90.0)
 
 `acra-webconfig` is a simple web application that provides web UI for AcraServer's runtime configuration.
 You can adjust the following parameters of AcraServer via `acra-webconfig`:

--- a/acra/configuring-maintaining/logging/_index.md
+++ b/acra/configuring-maintaining/logging/_index.md
@@ -21,7 +21,7 @@ Wondering what different logs, metrics, traces look like in Acra? Check out the 
 
 ## Configuring logging
 
-Logging mode and verbosity level can be configured for AcraServer, AcraConnector, AcraTranslator and AcraWebConfig in the corresponding `yaml` files or passed as CLI parameter.
+Logging mode and verbosity level can be configured for AcraServer, AcraConnector, AcraTranslator and AcraWebConfig (deprecated and removed after 0.90.0) in the corresponding `yaml` files or passed as CLI parameter.
 
 * `--logging_format`
   

--- a/acra/configuring-maintaining/logging/_index.md
+++ b/acra/configuring-maintaining/logging/_index.md
@@ -21,7 +21,7 @@ Wondering what different logs, metrics, traces look like in Acra? Check out the 
 
 ## Configuring logging
 
-Logging mode and verbosity level can be configured for AcraServer, AcraConnector, AcraTranslator and AcraWebConfig (deprecated and removed after 0.90.0) in the corresponding `yaml` files or passed as CLI parameter.
+Logging mode and verbosity level can be configured for AcraServer, AcraConnector, AcraTranslator and AcraWebConfig (deprecated and removed since 0.91.0) in the corresponding `yaml` files or passed as CLI parameter.
 
 * `--logging_format`
   

--- a/acra/configuring-maintaining/tracing/_index.md
+++ b/acra/configuring-maintaining/tracing/_index.md
@@ -62,4 +62,4 @@ Here are some of the traces and their subtraces collected by Acra services.
   tracks time of SecureSession/TLS handshakes for incoming connections
 
   * `<function>`
-    * if `handleCommandsConnection` — tracks processing time of command from AcraWebConfig
+    * if `handleCommandsConnection` — tracks processing time of requests to HTTP API.

--- a/acra/getting-started/installing/launching-acra-from-docker-images.md
+++ b/acra/getting-started/installing/launching-acra-from-docker-images.md
@@ -22,8 +22,8 @@ There are pre-built images that you can obtain from the [Docker Hub Cossack Labs
 * [`acra-tools`](https://hub.docker.com/r/cossacklabs/acra-tools) – with Acra tools including AcraKeymaker
 * [`acra-keymaker`](https://hub.docker.com/r/cossacklabs/acra-keymaker) – with AcraKeymaker (deprecated in favoe `acra-tools`)
 * [`acra-connector`](https://hub.docker.com/r/cossacklabs/acra-connector) – with AcraConnector
-* [`acra-authmanager`](https://hub.docker.com/r/cossacklabs/acra-authmanager) (deprecated after 0.90.0)– with AcraAuthmanager tool
-* [`acra-webconfig`](https://hub.docker.com/r/cossacklabs/acra-webconfig) (deprecated after 0.90.0) – with AcraWebconfig component
+* [`acra-authmanager`](https://hub.docker.com/r/cossacklabs/acra-authmanager) (deprecated since 0.91.0)– with AcraAuthmanager tool
+* [`acra-webconfig`](https://hub.docker.com/r/cossacklabs/acra-webconfig) (deprecated since 0.91.0) – with AcraWebconfig component
 
 Docker images have tags. When we build them, we set appropriate tags for each image:
 

--- a/acra/getting-started/installing/launching-acra-from-docker-images.md
+++ b/acra/getting-started/installing/launching-acra-from-docker-images.md
@@ -22,8 +22,8 @@ There are pre-built images that you can obtain from the [Docker Hub Cossack Labs
 * [`acra-tools`](https://hub.docker.com/r/cossacklabs/acra-tools) – with Acra tools including AcraKeymaker
 * [`acra-keymaker`](https://hub.docker.com/r/cossacklabs/acra-keymaker) – with AcraKeymaker (deprecated in favoe `acra-tools`)
 * [`acra-connector`](https://hub.docker.com/r/cossacklabs/acra-connector) – with AcraConnector
-* [`acra-authmanager`](https://hub.docker.com/r/cossacklabs/acra-authmanager) – with AcraAuthmanager tool
-* [`acra-webconfig`](https://hub.docker.com/r/cossacklabs/acra-webconfig) – with AcraWebconfig component
+* [`acra-authmanager`](https://hub.docker.com/r/cossacklabs/acra-authmanager) (deprecated after 0.90.0)– with AcraAuthmanager tool
+* [`acra-webconfig`](https://hub.docker.com/r/cossacklabs/acra-webconfig) (deprecated after 0.90.0) – with AcraWebconfig component
 
 Docker images have tags. When we build them, we set appropriate tags for each image:
 

--- a/acra/getting-started/trying/_index.md
+++ b/acra/getting-started/trying/_index.md
@@ -39,7 +39,7 @@ Now you can connect to (you can see the default DB name and credentials inside t
 | 9494/tcp | AcraConnector                | present AcraConnector                   |
 | 5432/tcp | PostgreSQL                   | PostgreSQL                              |
 | 3306/tcp | MySQL                        | MySQL                                   |
-| 8000/tcp | AcraWebconfig (deprecated and removed after 0.90.0) | present AcraConnector and SecureSession |
+| 8000/tcp | AcraWebconfig (deprecated and removed since 0.91.0) | present AcraConnector and SecureSession |
 
 Please refer to the [Launching Acra from Docker images](/acra/getting-started/installing/launching-acra-from-docker-images/) ff you need more information about Docker images.
 
@@ -47,7 +47,7 @@ Please refer to the [Launching Acra from Docker images](/acra/getting-started/in
 
 We want you to be able to easily try the most useful schemes that we prepared as Docker Compose files in the `docker` subdirectory. The name of each Docker Compose file describes its components and their interconnections in a simple form. For example: `docker-compose.pgsql-nossl-server-ssession-proxy.yml` is a scheme with Postgresql DB, AcraServer, and AcraConnector, connected to AcraServer through the Themis Secure Session link.
 
-The examples contain references to `acra-keymaker` and `acra-authmanager` (deprecated and removed after 0.90.0) containers inside. They are used for creation and distribution of the necessary keys. They were included for simplification of the test launch and should not be used in production schemes (where the keys should be generated manually and deployed to an appropriate host according to the security rules of your infrastructure).
+The examples contain references to `acra-keymaker` and `acra-authmanager` (deprecated and removed since 0.91.0) containers inside. They are used for creation and distribution of the necessary keys. They were included for simplification of the test launch and should not be used in production schemes (where the keys should be generated manually and deployed to an appropriate host according to the security rules of your infrastructure).
 
 Check out the [docker folder](https://github.com/cossacklabs/acra/blob/master/docker) for examples of compose files.
 
@@ -99,7 +99,7 @@ export MYSQL_PASSWORD="<user_password>"
 
 In order to access AcraWebConfig HTTP interface, you can define:
 {{< hint warning >}}
-Note that this component will be removed from Acra and docker-compose files after 0.90.0 version.
+Note that this component will be removed from Acra and docker-compose files since 0.91.0 version.
 {{< /hint >}}
 ```bash
 export ACRA_HTTPAUTH_USER=<http_auth_user>

--- a/acra/getting-started/trying/_index.md
+++ b/acra/getting-started/trying/_index.md
@@ -37,9 +37,9 @@ Now you can connect to (you can see the default DB name and credentials inside t
 | 9191/tcp | AcraServer/AcraConnector API | zonemode                                |
 | 9393/tcp | AcraServer                   | absent AcraConnector                    |
 | 9494/tcp | AcraConnector                | present AcraConnector                   |
-| 8000/tcp | AcraWebconfig                | present AcraConnector and SecureSession |
 | 5432/tcp | PostgreSQL                   | PostgreSQL                              |
 | 3306/tcp | MySQL                        | MySQL                                   |
+| 8000/tcp | AcraWebconfig (deprecated and removed after 0.90.0) | present AcraConnector and SecureSession |
 
 Please refer to the [Launching Acra from Docker images](/acra/getting-started/installing/launching-acra-from-docker-images/) ff you need more information about Docker images.
 
@@ -47,7 +47,7 @@ Please refer to the [Launching Acra from Docker images](/acra/getting-started/in
 
 We want you to be able to easily try the most useful schemes that we prepared as Docker Compose files in the `docker` subdirectory. The name of each Docker Compose file describes its components and their interconnections in a simple form. For example: `docker-compose.pgsql-nossl-server-ssession-proxy.yml` is a scheme with Postgresql DB, AcraServer, and AcraConnector, connected to AcraServer through the Themis Secure Session link.
 
-The examples contain references to `acra-keymaker` and `acra-authmanager` containers inside. They are used for creation and distribution of the necessary keys. They were included for simplification of the test launch and should not be used in production schemes (where the keys should be generated manually and deployed to an appropriate host according to the security rules of your infrastructure).
+The examples contain references to `acra-keymaker` and `acra-authmanager` (deprecated and removed after 0.90.0) containers inside. They are used for creation and distribution of the necessary keys. They were included for simplification of the test launch and should not be used in production schemes (where the keys should be generated manually and deployed to an appropriate host according to the security rules of your infrastructure).
 
 Check out the [docker folder](https://github.com/cossacklabs/acra/blob/master/docker) for examples of compose files.
 
@@ -98,6 +98,9 @@ export MYSQL_PASSWORD="<user_password>"
 ```
 
 In order to access AcraWebConfig HTTP interface, you can define:
+{{< hint warning >}}
+Note that this component will be removed from Acra and docker-compose files after 0.90.0 version.
+{{< /hint >}}
 ```bash
 export ACRA_HTTPAUTH_USER=<http_auth_user>
 export ACRA_HTTPAUTH_PASSWORD=<http_auth_password>

--- a/acra/guides/advanced-integrations/django-acra-tutorials/django-acra-step-by-step-tutorial.md
+++ b/acra/guides/advanced-integrations/django-acra-tutorials/django-acra-step-by-step-tutorial.md
@@ -45,7 +45,7 @@ with - [djangoproject.com](https://github.com/django/djangoproject.com) reposito
 Project to provide cryptographic protection of blog posts.
 
 Additionally, you can look on our [engineering demo](https://github.com/cossacklabs/acra-engineering-demo#examples-1-2-protecting-data-on-django-based-web-site) where we show how to run our example with docker-compose with all
-infrastructure supported by Acra: AcraConnector, AcraWebConfig, AcraAuthManager, Prometheus, Jaeger.
+infrastructure supported by Acra: AcraConnector, AcraWebConfig (deprecated after 0.90.0), AcraAuthManager (deprecated after 0.90.0), Prometheus, Jaeger.
 
 
 ## Security model

--- a/acra/guides/advanced-integrations/django-acra-tutorials/django-acra-step-by-step-tutorial.md
+++ b/acra/guides/advanced-integrations/django-acra-tutorials/django-acra-step-by-step-tutorial.md
@@ -45,7 +45,7 @@ with - [djangoproject.com](https://github.com/django/djangoproject.com) reposito
 Project to provide cryptographic protection of blog posts.
 
 Additionally, you can look on our [engineering demo](https://github.com/cossacklabs/acra-engineering-demo#examples-1-2-protecting-data-on-django-based-web-site) where we show how to run our example with docker-compose with all
-infrastructure supported by Acra: AcraConnector, AcraWebConfig (deprecated after 0.90.0), AcraAuthManager (deprecated after 0.90.0), Prometheus, Jaeger.
+infrastructure supported by Acra: AcraConnector, AcraWebConfig (deprecated since 0.91.0), AcraAuthManager (deprecated since 0.91.0), Prometheus, Jaeger.
 
 
 ## Security model

--- a/acra/guides/advanced-integrations/ruby-on-rails-acra-tutorials/ruby-on-rails-acra-short-tutorial.md
+++ b/acra/guides/advanced-integrations/ruby-on-rails-acra-tutorials/ruby-on-rails-acra-short-tutorial.md
@@ -105,4 +105,4 @@ Congratulations, you've integrated Acra with Ruby Gems.
 
 Additionally, you can look on our [engineering demo](https://github.com/cossacklabs/acra-engineering-demo#example-4-protecting-data-in-a-rails-application) 
 where we show how to run our example with docker-compose with all infrastructure supported by Acra: 
-AcraConnector, AcraWebConfig (deprecated after 0.90.0), AcraAuthManager (deprecated after 0.90.0), Prometheus, Jaeger.
+AcraConnector, AcraWebConfig (deprecated since 0.91.0), AcraAuthManager (deprecated since 0.91.0), Prometheus, Jaeger.

--- a/acra/guides/advanced-integrations/ruby-on-rails-acra-tutorials/ruby-on-rails-acra-short-tutorial.md
+++ b/acra/guides/advanced-integrations/ruby-on-rails-acra-tutorials/ruby-on-rails-acra-short-tutorial.md
@@ -105,4 +105,4 @@ Congratulations, you've integrated Acra with Ruby Gems.
 
 Additionally, you can look on our [engineering demo](https://github.com/cossacklabs/acra-engineering-demo#example-4-protecting-data-in-a-rails-application) 
 where we show how to run our example with docker-compose with all infrastructure supported by Acra: 
-AcraConnector, AcraWebConfig, AcraAuthManager, Prometheus, Jaeger.
+AcraConnector, AcraWebConfig (deprecated after 0.90.0), AcraAuthManager (deprecated after 0.90.0), Prometheus, Jaeger.

--- a/acra/security-controls/key-management/_index.md
+++ b/acra/security-controls/key-management/_index.md
@@ -14,7 +14,7 @@ Acra uses a multitude of encryption keys for different purposes:
   - keys for [searchable encryption](/acra/security-controls/searchable-encryption/) (if used);
   - keys for [tamper-proof audit logging](/acra/security-controls/security-logging-and-events/audit-logging) (if used);
   - poison record keys for [intrusion detection](/acra/security-controls/intrusion-detection/#poison-records) (if used);
-  - authentication storage key for encryption/decryption credentials of [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig) (deprecated after 0.90.0) users (if used).
+  - authentication storage key for encryption/decryption credentials of [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig) (deprecated since 0.91.0) users (if used).
 
 Acra Master Key is securely stored in [key management service (KMS)](/acra/acra-in-depth/architecture/key-storage-and-kms/#kms) or hardware security module (HSM). Other keys are encrypted and securely stored in a [**keystore**](versions) which is located either on the server's filesystem, or in [a remote key storage database](/acra/acra-in-depth/architecture/key-storage-and-kms/#key-storage).
 

--- a/acra/security-controls/key-management/_index.md
+++ b/acra/security-controls/key-management/_index.md
@@ -14,7 +14,7 @@ Acra uses a multitude of encryption keys for different purposes:
   - keys for [searchable encryption](/acra/security-controls/searchable-encryption/) (if used);
   - keys for [tamper-proof audit logging](/acra/security-controls/security-logging-and-events/audit-logging) (if used);
   - poison record keys for [intrusion detection](/acra/security-controls/intrusion-detection/#poison-records) (if used);
-  - authentication storage key for encryption/decryption credentials of [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig) users (if used).
+  - authentication storage key for encryption/decryption credentials of [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig) (deprecated after 0.90.0) users (if used).
 
 Acra Master Key is securely stored in [key management service (KMS)](/acra/acra-in-depth/architecture/key-storage-and-kms/#kms) or hardware security module (HSM). Other keys are encrypted and securely stored in a [**keystore**](versions) which is located either on the server's filesystem, or in [a remote key storage database](/acra/acra-in-depth/architecture/key-storage-and-kms/#key-storage).
 

--- a/acra/security-controls/key-management/inventory.md
+++ b/acra/security-controls/key-management/inventory.md
@@ -201,7 +201,7 @@ As poison records should look like encrypted data, you should generate either sy
 ### Authentication storage key
 
 {{< hint warning >}}
-It is deprecated and will not be used after 0.90.0.
+It is deprecated and will not be used since 0.91.0.
 {{< /hint >}}
 
 If you're using [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) to configure AcraServer remotely, the users' credentials are stored encrypted with authentication storage key and are decrypted on AcraServer upon users' login. AcraServer needs to have an authentication storage key.

--- a/acra/security-controls/key-management/inventory.md
+++ b/acra/security-controls/key-management/inventory.md
@@ -200,6 +200,10 @@ As poison records should look like encrypted data, you should generate either sy
 
 ### Authentication storage key
 
+{{< hint warning >}}
+It is deprecated and will not be used after 0.90.0.
+{{< /hint >}}
+
 If you're using [AcraWebConfig](/acra/configuring-maintaining/general-configuration/acra-webconfig/) to configure AcraServer remotely, the users' credentials are stored encrypted with authentication storage key and are decrypted on AcraServer upon users' login. AcraServer needs to have an authentication storage key.
 
 | Purpose  | Symmetric key  | Stays on

--- a/acra/security-controls/key-management/operations/generation.md
+++ b/acra/security-controls/key-management/operations/generation.md
@@ -146,7 +146,7 @@ AcraServer and AcraTranslator check this and will refuse to launch if access to 
 {{< /hint >}}
 
 {{< hint warning >}}
-`auth_key` is deprecated and will not be used after 0.90.0.
+`auth_key` is deprecated and will not be used since 0.91.0.
 {{< /hint >}}
 
 If you are running Acra 0.86+ and wish to try the new [keystore version 2](../../versions/),
@@ -182,7 +182,7 @@ In this case the directory layout will be a bit different:
 ```
 
 {{< hint warning >}}
-`authentication.keyring` is deprecated and will not be used after 0.90.0.
+`authentication.keyring` is deprecated and will not be used since 0.91.0.
 {{< /hint >}}
 
 ## 2. Setting up AcraConnector (optional)

--- a/acra/security-controls/key-management/operations/generation.md
+++ b/acra/security-controls/key-management/operations/generation.md
@@ -145,6 +145,10 @@ Stored keys should not be world-readable.
 AcraServer and AcraTranslator check this and will refuse to launch if access to the keys is not properly restricted.
 {{< /hint >}}
 
+{{< hint warning >}}
+`auth_key` is deprecated and will not be used after 0.90.0.
+{{< /hint >}}
+
 If you are running Acra 0.86+ and wish to try the new [keystore version 2](../../versions/),
 use `--keystore=v2` option when generating the keys:
 
@@ -176,6 +180,10 @@ In this case the directory layout will be a bit different:
 │           └── translator.keyring
 └── version
 ```
+
+{{< hint warning >}}
+`authentication.keyring` is deprecated and will not be used after 0.90.0.
+{{< /hint >}}
 
 ## 2. Setting up AcraConnector (optional)
 

--- a/acra/security-controls/key-management/operations/rotation.md
+++ b/acra/security-controls/key-management/operations/rotation.md
@@ -347,7 +347,7 @@ Try quering the migrated data to confirm that AcraServer or AcraTranslator are a
 There are some other keys which are not covered here:
 
   - master keys
-  - AcraWebconfig keys (deprecated after 0.90.0)
+  - AcraWebconfig keys (deprecated since 0.91.0)
   - poison record keys (do we need to rotate them at all?)
   - various Acra EE keys:
     - search token keys

--- a/acra/security-controls/key-management/operations/rotation.md
+++ b/acra/security-controls/key-management/operations/rotation.md
@@ -347,7 +347,7 @@ Try quering the migrated data to confirm that AcraServer or AcraTranslator are a
 There are some other keys which are not covered here:
 
   - master keys
-  - AcraWebconfig keys
+  - AcraWebconfig keys (deprecated after 0.90.0)
   - poison record keys (do we need to rotate them at all?)
   - various Acra EE keys:
     - search token keys


### PR DESCRIPTION
Added notes about deprecation for `authmanager`/`webconfig` mentions. 
You can see rendered pages on `docstatic-lagovas.<internal_dev_domain>`.
Didn't remove data about these components because they are actual for current state of Acra CE (even if I think that nobody use them :) and in the current docker-compose files.