### PR TITLE
update broken links; update searchable titles

### DIFF
--- a/acra/configuring-maintaining/key-storing/kms-integration.md
+++ b/acra/configuring-maintaining/key-storing/kms-integration.md
@@ -26,7 +26,7 @@ Only Acra Master Key loaded securely gives Acra access to intermediate keys and 
 
 The load could happen:
 
-* directly via environment variable (refer to [Configuring and maintaining / General configuration / Necessary preparations](/acra/configuring-maintaining/general-configuration/necessary-preparations/));
+* directly via environment variable (refer to [Security Controls / Key management](/acra/security-controls/key-management/operations/generation/#master-keys));
 
 * directly from KMS (AcraServer/AcraTranslator support KMS integration directly to read Acra Master Key, see [below](#supported-kmss));
 

--- a/themis/languages/cpp/examples.md
+++ b/themis/languages/cpp/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: "C++ examples"
 ---
 
 # Example projects with ThemisPP

--- a/themis/languages/cpp/features.md
+++ b/themis/languages/cpp/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: "C++ features"
 ---
 
 # Features of ThemisPP
@@ -825,7 +825,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/cpp/installation.md
+++ b/themis/languages/cpp/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: "C++ installation"
 ---
 
 # Installing ThemisPP

--- a/themis/languages/go/examples.md
+++ b/themis/languages/go/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: Go examples
 ---
 
 # Example projects with GoThemis

--- a/themis/languages/go/features.md
+++ b/themis/languages/go/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: Go features
 ---
 
 # Features of GoThemis
@@ -725,7 +725,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/go/installation.md
+++ b/themis/languages/go/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: Go installation
 ---
 
 # Installing GoThemis

--- a/themis/languages/java/examples.md
+++ b/themis/languages/java/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Examples
+title: Java examples
 ---
 
 # Example projects with JavaThemis

--- a/themis/languages/java/features.md
+++ b/themis/languages/java/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 5
-title:  Features
+title: Java features
 ---
 
 # Features of JavaThemis
@@ -893,7 +893,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/java/installation-android.md
+++ b/themis/languages/java/installation-android.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation for Android
+title: Android installation
 ---
 
 # Installing JavaThemis for Android development

--- a/themis/languages/java/installation-desktop.md
+++ b/themis/languages/java/installation-desktop.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Installation for desktop
+title: Java desktop installation
 ---
 
 # Installing JavaThemis for desktop development

--- a/themis/languages/kotlin/examples.md
+++ b/themis/languages/kotlin/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Examples
+title: Kotlin examples
 ---
 
 # Example projects with JavaThemis

--- a/themis/languages/kotlin/features.md
+++ b/themis/languages/kotlin/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 5
-title:  Features
+title: Kotlin features
 ---
 
 # Features of JavaThemis
@@ -872,7 +872,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/nodejs/examples.md
+++ b/themis/languages/nodejs/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: Node.js examples
 ---
 
 # Example projects with JsThemis

--- a/themis/languages/nodejs/features.md
+++ b/themis/languages/nodejs/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: Node.js features
 ---
 
 # Features of JsThemis
@@ -671,7 +671,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/nodejs/installation.md
+++ b/themis/languages/nodejs/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: Node.js installation
 ---
 
 # Installing JsThemis

--- a/themis/languages/objc/examples.md
+++ b/themis/languages/objc/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Examples
+title: ObjC examples
 ---
 
 # Example projects with ObjCThemis

--- a/themis/languages/objc/features.md
+++ b/themis/languages/objc/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 5
-title:  Features
+title: ObjC features
 ---
 
 # Features of ObjCThemis
@@ -823,7 +823,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/objc/installation.md
+++ b/themis/languages/objc/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: Swift/ObjC installation
 ---
 
 # Installing Themis for iOS and macOS

--- a/themis/languages/php/examples.md
+++ b/themis/languages/php/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: PHP examples
 ---
 
 # Example projects with PHPThemis

--- a/themis/languages/php/features.md
+++ b/themis/languages/php/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: PHP features
 ---
 
 # Features of PHPThemis

--- a/themis/languages/php/installation.md
+++ b/themis/languages/php/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: PHP installation
 ---
 
 # Installing PHPThemis

--- a/themis/languages/python/examples.md
+++ b/themis/languages/python/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: Python examples
 ---
 
 # Example projects with PyThemis

--- a/themis/languages/python/features.md
+++ b/themis/languages/python/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: Python features
 ---
 
 # Features of PyThemis
@@ -763,7 +763,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/python/installation.md
+++ b/themis/languages/python/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: Python installation
 ---
 
 # Installing PyThemis

--- a/themis/languages/ruby/examples.md
+++ b/themis/languages/ruby/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: Ruby examples
 ---
 
 # Example projects with RbThemis

--- a/themis/languages/ruby/features.md
+++ b/themis/languages/ruby/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: Ruby features
 ---
 
 # Features of RbThemis
@@ -639,7 +639,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/ruby/installation.md
+++ b/themis/languages/ruby/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: Ruby installation
 ---
 
 # Installing RbThemis

--- a/themis/languages/rust/examples.md
+++ b/themis/languages/rust/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title: Rust examples
 ---
 
 # Example projects with RustThemis

--- a/themis/languages/rust/features.md
+++ b/themis/languages/rust/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title: Rust features
 ---
 
 # Features of RustThemis
@@ -807,7 +807,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/rust/installation.md
+++ b/themis/languages/rust/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title: Rust installation
 ---
 
 # Installing RustThemis

--- a/themis/languages/swift/examples.md
+++ b/themis/languages/swift/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Examples
+title: Swift examples
 ---
 
 # Example projects with SwiftThemis

--- a/themis/languages/swift/features.md
+++ b/themis/languages/swift/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 5
-title:  Features
+title: Swift features
 ---
 
 # Features of SwiftThemis
@@ -784,7 +784,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/wasm/examples.md
+++ b/themis/languages/wasm/examples.md
@@ -1,6 +1,6 @@
 ---
 weight: 3
-title:  Examples
+title:  WASM examples
 ---
 
 # Example projects with WasmThemis

--- a/themis/languages/wasm/features.md
+++ b/themis/languages/wasm/features.md
@@ -1,6 +1,6 @@
 ---
 weight: 4
-title:  Features
+title:  WASM features
 ---
 
 # Features of WasmThemis
@@ -687,7 +687,7 @@ It is built around a [_Zero-Knowledge Proof_][ZKP]-based protocol
 ([Socialist Millionaire's Protocol][SMP]),
 with a number of [security enhancements][paper].
 
-[ZKP]: https://www.cossacklabs.com/zero-knowledge-protocols-without-magic.html
+[ZKP]: https://www.cossacklabs.com/blog/zero-knowledge-protocols-without-magic/
 [SMP]: https://en.wikipedia.org/wiki/Socialist_millionaire_problem
 [paper]: https://www.cossacklabs.com/files/secure-comparator-paper-rev12.pdf
 

--- a/themis/languages/wasm/installation.md
+++ b/themis/languages/wasm/installation.md
@@ -1,6 +1,6 @@
 ---
 weight: 2
-title:  Installation
+title:  WASM installation
 ---
 
 # Installing WasmThemis


### PR DESCRIPTION
1. update broken links in themis and acra
2. themis: change searchable titles to avoid "installation installation installation installation .." search results

<img width="252" alt="Screenshot 2021-11-25 at 19 17 09" src="https://user-images.githubusercontent.com/2877920/143481903-a4e1443a-90c0-4212-9b47-9a509c591a7d.png">

