### PR TITLE
Mark GET method for AT HTTP api as deprecated

### DIFF
--- a/acra/guides/integrating-acra-translator-into-new-infrastructure/http_api.md
+++ b/acra/guides/integrating-acra-translator-into-new-infrastructure/http_api.md
@@ -34,7 +34,7 @@ If you need to perform multiple parallel operations within single network reques
 
 #### Request
 
-Method: `GET`
+Method: `POST`, `GET` (deprecated since 0.91.0)
 
 Path: `/v2/bulkProcessing`
 

--- a/acra/security-controls/encryption/_index.md
+++ b/acra/security-controls/encryption/_index.md
@@ -259,7 +259,7 @@ service ReaderSym {
 
 #### Request
 
-Method: `GET`
+Method: `POST`, `GET` (deprecated since 0.91.0)
 
 Mime-Type: `application/json`
 

--- a/acra/security-controls/searchable-encryption/_index.md
+++ b/acra/security-controls/searchable-encryption/_index.md
@@ -173,7 +173,7 @@ And because of this difference you should not mix them, `encrypt`+`decryptSearch
 
 #### Encryption/decryption request
 
-Method: `GET`
+Method: `POST`, `GET` (deprecated since 0.91.0)
 
 Mime-Type: `application/json`
 
@@ -219,7 +219,7 @@ In case of error:
 
 #### Hash generation request
 
-Method: `GET`
+Method: `POST`, `GET` (deprecated since 0.91.0)
 
 Path: `/v2/generateQueryHash`
 

--- a/acra/security-controls/tokenization/_index.md
+++ b/acra/security-controls/tokenization/_index.md
@@ -112,7 +112,7 @@ Don't forget to use the same type (str / email / int32 / int64 / bytes).
 
 #### Request
 
-Method: `GET`
+Method: `POST`, `GET` (deprecated since 0.91.0)
 
 Path: `/v2/tokenize` for tokenization, `/v2/detokenize` for detokenization
 
@@ -162,14 +162,14 @@ This example includes few simple ones.
 
 ```
 curl \
-    --request GET \
+    --request POST \
     --header 'Content-Type: application/json' \
     --data '{"zone_id":"","type":3,"data":"hidden message"}' \
     http://127.0.0.1:9494/v2/tokenize
 {"data":"CWce2KYUPVYHlq"}
 
 curl \
-    --request GET \
+    --request POST \
     --header 'Content-Type: application/json' \
     --data '{"zone_id":"","type":5,"data":"me@domain.com"}' \
     http://127.0.0.1:9494/v2/tokenize


### PR DESCRIPTION
Has marked as deprecated and updated examples of requests to AT.