### PR TITLE
add "troubleshooting installation" page for themis

### DIFF
--- a/themis/debugging/cli-utilities.md
+++ b/themis/debugging/cli-utilities.md
@@ -1,6 +1,6 @@
 ---
-weight: 2
-title:  CLI utilities
+weight: 3
+title: CLI utilities
 ---
 
 # Command-line utilities

--- a/themis/debugging/themis-server.md
+++ b/themis/debugging/themis-server.md
@@ -1,6 +1,6 @@
 ---
-weight: 3
-title:  Themis Server
+weight: 4
+title: Themis Server
 ---
 
 # Themis Server

--- a/themis/debugging/thread-safety.md
+++ b/themis/debugging/thread-safety.md
@@ -1,6 +1,6 @@
 ---
-weight: 4
-title:  Thread safety
+weight: 5
+title: Thread safety
 ---
 
 # Thread safety

--- a/themis/debugging/troubleshooting-installation.md
+++ b/themis/debugging/troubleshooting-installation.md
@@ -1,0 +1,19 @@
+---
+weight: 2
+title: Troubleshooting installation
+---
+
+# Troubleshooting installation
+
+
+## Troubleshooting installation on Ubuntu
+
+### Expired Let's Encrypt root certificate
+
+If you see errors like "Certificate verification failed" or "gpg: no valid OpenPGP data found" when [installing Themis Core](/themis/installation/installation-from-packages/) on Ubuntu, make sure that OS uses the latest [Let's Encrypt root certificate](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/).
+
+```bash
+$ sed -i 's|mozilla/DST_Root_CA_X3.crt|!mozilla/DST_Root_CA_X3.crt|' /etc/ca-certificates.conf
+$ update-ca-certificates
+```
+ 

--- a/themis/installation/installation-from-packages.md
+++ b/themis/installation/installation-from-packages.md
@@ -10,6 +10,8 @@ title:  Installation from packages
 The core library is available via Cossack Labs package repositories.
 Follow the instructions below for your operating system.
 
+In case you experience issues during installation, refer to [Troubleshooting installation](/themis/debugging/troubleshooting-installation/) page which contains the wisdom of ages.
+
 ### Debian, Ubuntu
 
 Supported systems:
@@ -29,7 +31,6 @@ You need to import the public key used by Cossack Labs to sign packages:
 wget -qO - https://pkgs-ce.cossacklabs.com/gpg | sudo apt-key add -
 ```
 
-{{< hint info >}}
 If you wish to validate the key fingerprint, it is:
 ```
 $ apt-key list 'Cossack Labs'
@@ -37,7 +38,6 @@ pub   rsa4096 2017-07-14 [SC]
       29CF C579 AD90 8838 3E37  A8FA CE53 BCCA C8FF FACB
 uid           [ unknown] Cossack Labs Limited <dev@cossacklabs.com>
 ```
-{{< /hint >}}
 
 **2. Make sure APT supports HTTPS**
 


### PR DESCRIPTION
Based on the numerous ~weird questions~ inquiries from the community, we've created "troubleshooting installation" page for Themis.

Important to remember: all `Hx` headers are shown in the search, so it makes sense for the Troubleshooting page to contain headers that start with "Troubleshooting" to easily distinguish them in searchbox.


<img width="759" alt="Screenshot 2021-11-30 at 16 31 29" src="https://user-images.githubusercontent.com/2877920/144066278-236f081d-2874-43d3-aa06-9a4d1e35ad86.png">

<img width="1045" alt="Screenshot 2021-11-30 at 16 31 33" src="https://user-images.githubusercontent.com/2877920/144066308-942b9b40-de05-4ac4-a552-68df13e25039.png">

