### PR TITLE
Sync guides for AT&AS [T2308]

### DIFF
--- a/acra/acra-in-depth/architecture/acraserver.md
+++ b/acra/acra-in-depth/architecture/acraserver.md
@@ -5,12 +5,19 @@ weight: 2
 
 # AcraServer, an SQL database proxy
 
-AcraServer is also known as SQL Proxy. It's SQL database proxy that exposes Acra’s functionality by parsing SQL traffic between an app and a database and applying security functions where appropriate. 
+## How AcraServer works
 
-If you'd like to encrypt the data between your app and SQL database "transparently on-a-fly" then AcraServer should be your main choice.
+AcraServer is database protocol aware proxy between application and MySQL/PostgreSQL that does next:
+
+- captures all packets from database driver to database and back
+- recognizes packets related to SQL queries or data transferring
+- passes SQL queries through [AcraCensor SQL firewall]({{< ref "/acra/security-controls/sql-firewall" >}}) before further processing
+- encrypt/tokenize/mask all recognized plaintext data according to [encryptor config]({{< ref "acra/security-controls/encryption/#acraServer-configuration" >}}) 
+  and pass further as it was sent by application
+- decrypt/detokenize/unmask data from database to application as it was sent by database
+- check on intrusion detection via recognizing [poison records]({{<ref "/acra/security-controls/intrusion-detection/" >}})
 
 Refer to [Integrating AcraServer into infrastructure](/acra/guides/integrating-acra-server-into-infrastructure/) to learn how configure AcraServer.
-
 
 ## AcraServer's functionality
 

--- a/acra/acra-in-depth/architecture/acratranslator.md
+++ b/acra/acra-in-depth/architecture/acratranslator.md
@@ -5,7 +5,26 @@ weight: 3
 
 # AcraTranslator, an API service
 
-AcraTranslator is an API server, that exposes most of Acra’s features as HTTP / gRPC API with client SDKs and traffic protection. AcraTranslator doesn't depend on a database and makes application responsible for actually putting data into storage.
+AcraTranslator is an API server, that exposes most of Acra’s features as 
+[HTTP](/acra/guides/integrating-acra-translator-into-new-infrastructure/http_api/) or
+[gRPC](/acra/guides/integrating-acra-translator-into-new-infrastructure/grpc_api/) API with client SDKs and traffic 
+protection. This element of Acra is necessary in the use-cases when applications store the encrypted data as separate blobs (files
+that are not in a database - i.e. in the S3 bucket, local file storage, etc.).
+
+By its nature, AcraTranslator is a separate daemon that runs in an isolated environment (separate virtual machine or
+physical server). AcraTranslator is responsible for holding all the secrets required for data decryption and for
+actually decrypting the data.
+
+AcraTranslator doesn't care about the source of the data, it accepts
+[AcraStructs] or [AcraBlocks] via HTTP or gRPC API. An application can conveniently store crypto envelope anywhere: as
+cells in the database, as files in the file storage (local or cloud storage, like S3).
+An application sends [AcraStructs] or [AcraBlocks] as binary data and receives plaintext (or decryption error) from AcraTranslator.
+
+However, sending plaintext data via a non-secure channel is a bad idea, so AcraTranslator requires usage of
+[Themis Secure Session] or [TLS] encryption channel (which is basically
+encrypted TCP/UNIX sockets).
+To establish a Themis Secure Session connection, an application doesn't need to include the crypto-code itself, only to
+direct the traffic through [AcraConnector](/acra/configuring-maintaining/general-configuration/acra-connector/) instead.
 
 AcraTranslator is your the main choice when your application should make encryption calls, or you use NoSQL/KV datastore.
 

--- a/acra/acra-in-depth/architecture/acratranslator.md
+++ b/acra/acra-in-depth/architecture/acratranslator.md
@@ -16,13 +16,15 @@ physical server). AcraTranslator is responsible for holding all the secrets requ
 actually decrypting the data.
 
 AcraTranslator doesn't care about the source of the data, it accepts
-[AcraStructs] or [AcraBlocks] via HTTP or gRPC API. An application can conveniently store crypto envelope anywhere: as
+[AcraStructs](/acra/acra-in-depth/data-structures/acrastruct/) or [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock/) 
+via HTTP or gRPC API. An application can conveniently store crypto envelope anywhere: as
 cells in the database, as files in the file storage (local or cloud storage, like S3).
-An application sends [AcraStructs] or [AcraBlocks] as binary data and receives plaintext (or decryption error) from AcraTranslator.
+An application sends [AcraStructs](/acra/acra-in-depth/data-structures/acrastruct/) or [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock/) 
+as binary data and receives plaintext (or decryption error) from AcraTranslator.
 
 However, sending plaintext data via a non-secure channel is a bad idea, so AcraTranslator requires usage of
-[Themis Secure Session] or [TLS] encryption channel (which is basically
-encrypted TCP/UNIX sockets).
+[Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/) or [TLS](/acra/configuring-maintaining/general-configuration/acra-translator/#tls) 
+encryption channel (which is basically encrypted TCP/UNIX sockets).
 To establish a Themis Secure Session connection, an application doesn't need to include the crypto-code itself, only to
 direct the traffic through [AcraConnector](/acra/configuring-maintaining/general-configuration/acra-connector/) instead.
 

--- a/acra/configuring-maintaining/general-configuration/acra-translator.md
+++ b/acra/configuring-maintaining/general-configuration/acra-translator.md
@@ -15,7 +15,8 @@ weight: 4
 
 * `--acratranslator_client_id_from_connection_enable={true|false}`
 
-  Use clientID from TLS certificates or secure session handshake.
+  Use clientID from TLS certificates or secure session handshake for gRPC requests. It doesn't change clientID usage
+  for HTTP API requests.
   Default is `false` which means "use the one passed in gRPC methods".
 
 * `--audit_log_enable={true|false}`
@@ -191,6 +192,11 @@ weight: 4
   Default is `0`.
 
 ### TLS
+
+* `--acratranslator_tls_transport_enable={true|false}`
+
+  Use TLS transport (tcp/unix socket) between AcraTranslator and client app.
+  Default is `false`.
 
 * `--tls_auth=<mode>`
 

--- a/acra/guides/integrating-acra-server-into-infrastructure/_index.md
+++ b/acra/guides/integrating-acra-server-into-infrastructure/_index.md
@@ -6,6 +6,11 @@ weight: 1
 
 # Integrating AcraServer into infrastructure
 
+## How AcraServer works
+
+Refer to [AcraServer architecture]({{< ref "/acra/acra-in-depth/architecture/acraserver.md" >}}) page to find out
+deep description of internals and how it works.
+
 ## AcraServer installation
 
 There are multiple ways to install AcraServer.
@@ -70,6 +75,14 @@ As soon as you have running instance of AcraServer, you can try redirecting you 
 * Change the `host:port` part of connection to make application connect to AcraServer
 * Make sure application will accept TLS certificate configured in AcraServer
 * No need to change database credentials
+
+## Poison records
+
+If the client application is hacked and the attacker is trying to decrypt all the data, you can detect it using [poison records](/acra/security-controls/intrusion-detection/).
+
+AcraServer (similarly as AcraTranslator) has ability to detect poison records and stop executing the request,
+preventing the data from leaking to an untrusted destination.
+To learn more about AcraServer cmd configuration you can refer [here](/acra/configuring-maintaining/general-configuration/acra-server/).
 
 ### AcraWriter integration (optional)
 

--- a/acra/guides/integrating-acra-server-into-infrastructure/client_id.md
+++ b/acra/guides/integrating-acra-server-into-infrastructure/client_id.md
@@ -6,7 +6,7 @@ weight: 2
 
 # Client ID
 
-Every application wishing to interact with AcraServer shoud provide an identifier called client ID.
+Every application wishing to interact with AcraServer should provide an identifier called client ID.
 Based on the client ID, AcraServer will choose corresponding encryption keys to process client requests.
 
 There are two ways of passing client ID from application to AcraServer:

--- a/acra/guides/integrating-acra-translator-into-new-infrastructure/_index.md
+++ b/acra/guides/integrating-acra-translator-into-new-infrastructure/_index.md
@@ -51,12 +51,15 @@ different client ID.
 
 Acra design values simplicity as much as security.
 
-1. The application sends [AcraStructs] or [AcraBlocks] via HTTP or gRPC API.
-2. AcraConnector sends that request to AcraTranslator using [Themis Secure Session] (socket protection protocol).
-3. AcraTranslator accepts the request and attempts to decrypt an [AcraStruct] or [AcraBlock]. If the decryption is
-   successful, it sends the resulting plaintext in the response. If decryption fails, AcraTranslator sends out a
-   decryption error.
-4. AcraTranslator returns the data to AcraConnector (via [Themis Secure Session]), which in turn returns it to the application.
+1. The application sends [AcraStructs](/acra/acra-in-depth/data-structures/acrastruct/) or 
+   [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock/) via HTTP or gRPC API.
+2. AcraConnector sends that request to AcraTranslator using [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/) 
+   (socket protection protocol).
+3. AcraTranslator accepts the request and attempts to decrypt an [AcraStruct](/acra/acra-in-depth/data-structures/acrastruct/) 
+   or [AcraBlock](/acra/acra-in-depth/data-structures/acrablock/). If the decryption is successful, it sends the 
+   resulting plaintext in the response. If decryption fails, AcraTranslator sends out a decryption error.
+4. AcraTranslator returns the data to AcraConnector (via [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/)), 
+   which in turn returns it to the application.
 
 AcraTranslator reads decryption keys from key folder and stores them encrypted in memory. It uses LRU cache to increase
 performance by keeping only actively used keys in memory. The size of LRU cache can be configured depending on your
@@ -64,7 +67,7 @@ server's load.
 
 {{< hint warning >}}
 **Note:**
-AcraTranslator supports ability to use [TLS] as encryption channel instead of [Themis Secure Session].
+AcraTranslator supports ability to use [TLS] as encryption channel instead of [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/).
 In such case, you don't need to use AcraConnector, but you should manage all your TLS certificates manually.
 {{< /hint >}}
 
@@ -118,9 +121,3 @@ To learn more about AcraTranslator cmd configuration you can refer [here](/acra/
   describes encryption configuration more precisely, describes how AcraTranslator encrypts/decrypts data on the fly
 * [docker-compose examples](https://github.com/cossacklabs/acra/tree/master/docker)
   may give you various ideas about AcraTranslator integration in docker environment
-
-[AcraTranslator]: /acra/configuring-maintaining/general-configuration/acra-translator/
-[AcraStructs]: /acra/acra-in-depth/data-structures/acrastruct/
-[AcraBlocks]: /acra/acra-in-depth/data-structures/acrablock/
-[Themis Secure Session]: /themis/crypto-theory/cryptosystems/secure-session/
-[TLS]: /acra/configuring-maintaining/general-configuration/acra-translator/#tls

--- a/acra/guides/integrating-acra-translator-into-new-infrastructure/_index.md
+++ b/acra/guides/integrating-acra-translator-into-new-infrastructure/_index.md
@@ -4,21 +4,46 @@ bookCollapseSection: true
 weight: 2
 ---
 
-## Usage of AcraTranslator
+# Integrating AcraTranslator into infrastructure
 
-[AcraTranslator](/acra/configuring-maintaining/general-configuration/acra-translator/) is a lightweight server used to handle [
-AcraStructs](/acra/acra-in-depth/data-structures/acrastruct) and [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock) in context of tokenization, searchable or simple encryption/decryption via [HTTP](/acra/guides/integrating-acra-translator-into-new-infrastructure/http_api/) or [gRPC](/acra/guides/integrating-acra-translator-into-new-infrastructure/grpc_api/) API.
-This element of Acra is necessary in the use-cases when applications store the encrypted data as separate blobs (files that are not in a database - i.e. in the S3 bucket, local file storage, etc.).
+## How AcraTranslator works
 
-By its nature, AcraTranslator is a separate daemon that runs in an isolated environment (separate virtual machine or physical server). AcraTranslator is responsible for holding all the secrets required for data decryption and for actually decrypting the data.
+Refer to [AcraTranslator architecture]({{< ref "/acra/acra-in-depth/architecture/acratranslator.md" >}}) page to find out
+deep description of internals and how it works.
 
-AcraTranslator doesn't care about the source of the data, it accepts [AcraStructs](/acra/acra-in-depth/data-structures/acrastruct) or [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock) via HTTP or gRPC API. An application can conveniently store crypto envelope anywhere: as cells in the database, as files in the file storage (local or cloud storage, like S3).
-An application sends [AcraStructs](/acra/acra-in-depth/data-structures/acrastruct) or [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock) as binary data and receives plaintext (or decryption error) from AcraTranslator.
+## AcraTranslator installation
 
-However, sending plaintext data via a non-secure channel is a bad idea, so AcraTranslator requires usage of [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/) or [TLS](/acra/configuring-maintaining/general-configuration/acra-translator/#tls) encryption channel (which is basically encrypted TCP/UNIX sockets).
-To establish a Themis Secure Session connection, an application doesn't need to include the crypto-code itself, only to direct the traffic through [AcraConnector](/acra/configuring-maintaining/general-configuration/acra-connector/) instead.
+There are multiple ways to install AcraTranslator.
+You will also need utilities like `acra-keys` that come along.
 
+* [Install package from a repo]({{< ref "acra/getting-started/installing/installing-acra-from-repository.md">}})
+* [Use Docker images]({{< ref "acra/getting-started/installing/launching-acra-from-docker-images.md">}})
+* [Install from sources]({{< ref "acra/getting-started/installing/installing-acra-from-sources.md">}})
 
+## Key generation
+
+You will need some keys in order to launch AcraServer, so let's do it first.
+
+1. [Generate a master key]({{< ref "acra/security-controls/key-management/operations/generation.md#11-generating-acra-master-key">}})
+2. [Generate encryption keys]({{< ref "acra/security-controls/key-management/operations/generation.md#12-generating-transport-and-encryption-keys">}})
+
+The first one will be used to protect all the other keys,
+it should be base64-encoded and passed to Acra services in `ACRA_MASTER_KEY` environment variable.
+
+Like this: `ACRA_MASTER_KEY="$(cat /tmp/master_key | base64)" acra-server ...`
+
+The second key is responsible for data encryption.
+There are actually more kinds of keys, read more about that on
+[Acra keys inventory]({{< ref "acra/security-controls/key-management/inventory.md" >}}).
+
+It is also possible to store keys in a Redis database, see
+[Scalable KV storages]({{< ref "acra/configuring-maintaining/key-storing/kv-stores.md#redis" >}}).
+
+### Note about Client ID
+
+When generating a key, you will always have to bind it with a [Cliend ID]({{< ref "client_id.md" >}}) or Zone ID.
+AcraTranslator distinguishes requests by [Client ID]({{< ref "client_id.md" >}}) and uses different encryption keys for 
+different client ID.
 
 ## Architecture and DataFlow of AcraTranslator-based infrastructure
 
@@ -26,33 +51,76 @@ To establish a Themis Secure Session connection, an application doesn't need to 
 
 Acra design values simplicity as much as security.
 
-1. The application sends [AcraStructs](/acra/acra-in-depth/data-structures/acrastruct) or [AcraBlocks](/acra/acra-in-depth/data-structures/acrablock) via HTTP or gRPC API.
-2. AcraConnector sends that request to AcraTranslator using [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/) (socket protection protocol).
-3. AcraTranslator accepts the request and attempts to decrypt an [AcraStruct](/acra/acra-in-depth/data-structures/acrastruct) or [AcraBlock](/acra/acra-in-depth/data-structures/acrablock). If the decryption is successful, it sends the resulting plaintext in the response. If decryption fails, AcraTranslator sends out a decryption error.
-4. AcraTranslator returns the data to AcraConnector (via [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/)), which in turn returns it to the application.
+1. The application sends [AcraStructs] or [AcraBlocks] via HTTP or gRPC API.
+2. AcraConnector sends that request to AcraTranslator using [Themis Secure Session] (socket protection protocol).
+3. AcraTranslator accepts the request and attempts to decrypt an [AcraStruct] or [AcraBlock]. If the decryption is
+   successful, it sends the resulting plaintext in the response. If decryption fails, AcraTranslator sends out a
+   decryption error.
+4. AcraTranslator returns the data to AcraConnector (via [Themis Secure Session]), which in turn returns it to the application.
 
-AcraTranslator reads decryption keys from key folder and stores them encrypted in memory. It uses LRU cache to increase performance by keeping only actively used keys in memory. The size of LRU cache can be configured depending on your server's load.
+AcraTranslator reads decryption keys from key folder and stores them encrypted in memory. It uses LRU cache to increase
+performance by keeping only actively used keys in memory. The size of LRU cache can be configured depending on your
+server's load.
 
 {{< hint warning >}}
 **Note:**
-AcraTranslator supports ability to use [TLS](/acra/configuring-maintaining/general-configuration/acra-translator/#tls) as encryption channel instead of [Themis Secure Session](/themis/crypto-theory/cryptosystems/secure-session/). In such case, you don't need to use AcraConnector, but you should manage all your TLS certificates manually.
+AcraTranslator supports ability to use [TLS] as encryption channel instead of [Themis Secure Session].
+In such case, you don't need to use AcraConnector, but you should manage all your TLS certificates manually.
 {{< /hint >}}
 
+## AcraTranslator configuration
 
-## Configuration
-Before doing any configuration, make sure you have properly [installed AcraTranslator](/acra/getting-started/installing/installing-acra-from-sources/).
+Refer to [AcraTranslator configuration]({{< ref "acratranslator_configuration.md" >}}) page.
 
-Additionally, you can [Setup AcraTranslator using Docker](/acra/getting-started/installing/launching-acra-from-docker-images/)
+## AcraConnector (optional)
 
-After AcraTranslator installed you can follow manual configuration steps for [HTTP](/acra/guides/integrating-acra-translator-into-new-infrastructure/http_api/) or [gRPC](/acra/guides/integrating-acra-translator-into-new-infrastructure/grpc_api/) API.
+AcraConnector is as intermediate proxy between the application and AcraTranslator.
+Why would you need yet another proxy? Well, there are a couple of reasons:
+
+* Providing secure transport to AcraTranslator:
+  if application does not support TLS, communicates with AcraTranslator on remote host, and you want to ensure the 
+  communication channel is safe
+* Specifying which Client ID to use:
+  when using TLS, you will have to use client IDs derived from some certificate properties (such as serial number),
+  but with AcraConnector you can use whatever ID you want by simply setting configuration option when launching AcraConnector
+
+AcraConnector usually lives on the same host as the application, but is isolated a bit
+(running as different user, in separate docker container and so on).
+
+Read more in [Client side encryption with AcraConnector and AcraWriter]({{< ref "acra/guides/advanced-integrations/client-side-integration-with-acra-connector.md" >}}).
+
+## Changes on application side
+
+* Teach application to work with AcraTranslator API. Generate code for gRPC client or write own to work with HTTP API
+* Make sure application will accept TLS certificate configured in AcraTranslator in case of usage TLS as transport protection
+* Up and configure AcraConnector close to application in case of usage SecureSession as transport protection
+
+### AcraWriter integration (optional)
+
+One of the things available in enterprise edition is
+[part of SDK called AcraWriter]({{< ref "acra/acra-in-depth/architecture/sdks/acrawriter.md" >}})
+that allows data encryption right inside the application for `Encrypt` operations via gRPC/HTTP API calls.
 
 
 ## Poison records
 
 If the client application is hacked and the attacker is trying to decrypt all the data, you can detect it using [poison records](/acra/security-controls/intrusion-detection/).
 
-AcraTranslator (similarly as AcraServer) has ability to detect poison records and stop executing the query, preventing the data from leaking to an untrusted destination.
+AcraTranslator (similarly as AcraServer) has ability to detect poison records and stop executing the request, 
+preventing the data from leaking to an untrusted destination.
 To learn more about AcraTranslator cmd configuration you can refer [here](/acra/configuring-maintaining/general-configuration/acra-translator/).
 
+## Read more
 
+* [Storage and data model implications]({{< ref "acra/configuring-maintaining/storage-and-data-model-implications/" >}})
+  lists current limitations introduced when using AcraTranslator
+* [Encryption docs]({{< ref "acra/security-controls/encryption/_index.md" >}})
+  describes encryption configuration more precisely, describes how AcraTranslator encrypts/decrypts data on the fly
+* [docker-compose examples](https://github.com/cossacklabs/acra/tree/master/docker)
+  may give you various ideas about AcraTranslator integration in docker environment
 
+[AcraTranslator]: /acra/configuring-maintaining/general-configuration/acra-translator/
+[AcraStructs]: /acra/acra-in-depth/data-structures/acrastruct/
+[AcraBlocks]: /acra/acra-in-depth/data-structures/acrablock/
+[Themis Secure Session]: /themis/crypto-theory/cryptosystems/secure-session/
+[TLS]: /acra/configuring-maintaining/general-configuration/acra-translator/#tls

--- a/acra/guides/integrating-acra-translator-into-new-infrastructure/acratranslator_configuration.md
+++ b/acra/guides/integrating-acra-translator-into-new-infrastructure/acratranslator_configuration.md
@@ -1,0 +1,36 @@
+---
+title: AcraTranslator configuration
+bookCollapseSection: true
+weight: 1
+---
+
+# AcraTranslator configuration
+
+Here we describe how to set up AcraTranslator to reach a state where it can process queries.
+
+List of all command line flags for AcraTranslator is located
+[here]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md" >}}).
+
+## Configuration file
+
+There are two ways of configuring AcraServer:
+* via command line flags
+* via configuration file
+
+The YAML file is passed with `--config_file=path/to/config.yml` flag.
+To use this file as configuration source, you simply move flags into it,
+`--foo=1` will become `foo: 1` and `--bar=test` will become `bar: "test"`.
+
+Different configuration sources can be mixed if that makes sense in your situation.
+
+## Listener
+
+AcraTranslator will be listening on some default ports (gRPC API on `9696`, HTTP API on `9595`) if not configured to do otherwise.
+Related flags are located [here]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md" >}}) 
+and described for flag names: `incoming_connection_grpc_string` and `incoming_connection_http_string`.
+As a simple example we can set both like this: `--incoming_connection_grpc_string=tcp://127.0.0.1:13306` and 
+`--incoming_connection_http_string=tcp://127.0.0.1:13307`.
+
+It is also important to [configure TLS]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md#tls" >}})
+so the application/clients will have secure connection to AcraTranslator.
+In some cases, you may want to use AcraConnector + Themis Secure Session instead of TLS.

--- a/acra/guides/integrating-acra-translator-into-new-infrastructure/client_id.md
+++ b/acra/guides/integrating-acra-translator-into-new-infrastructure/client_id.md
@@ -1,0 +1,48 @@
+---
+title: Client ID
+bookCollapseSection: true
+weight: 2
+---
+
+# Client ID
+
+Every application wishing to protect their data with AcraTranslator should provide an identifier called client ID.
+Based on the client ID, AcraTranslator will choose corresponding encryption keys to process client requests.
+
+The way how application can pass client ID to AcraTranslator depends on API type: gRPC or HTTP.
+
+## gRPC API
+
+By default, application have to specify `client ID` in every request was sent to AcraTranslator except when
+`--acratranslator_client_id_from_connection_enable` flag used. Every type of request declared in 
+[*.proto file](https://github.com/cossacklabs/acra/blob/stable/cmd/acra-translator/grpc_api/api.proto) has `client_id`
+required parameter.
+
+It can be changed with `--acratranslator_client_id_from_connection_enable` flag that configures AcraTranslator to 
+extract client ID value from incoming connections. AcraTranslator accepts only TLS connections with mutual authentication
+or proxied through AcraConnector
+
+## HTTP API
+
+AcraTranslator uses client ID derived from client's certificates in TLS handshakes (mutual authentication required) or
+SecureSession connections through AcraConnector similar to gRPC requests with `--acratranslator_client_id_from_connection_enable`
+flag.
+
+## AcraConnector
+
+AcraTranslator will use client ID sent by AcraConnector for HTTP API by default and for gRPC API if launched with
+[`--acratranslator_client_id_from_connection_enable`]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md#command-line-flags" >}}).
+
+When using AcraConnector, set the client ID with `--client_id` flag and connect to AcraConnector instead of AcraServer.
+
+See more information [here]({{< ref "/acra/security-controls/transport-security/acra-connector.md" >}}).
+
+## TLS certificate
+
+When AcraTranslator is launched with [`--acratranslator_tls_transport_enable`]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md#tls" >}}) flag
+for HTTP API or additionally with [`--acratranslator_client_id_from_connection_enable`]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md#command-line-flags" >}}) 
+flag, client IDs will be derived from TLS certificates provided by the client during handshake.
+
+The exact behavior will also depend on value from
+[`--tls_identifier_extractor_type`]({{< ref "acra/configuring-maintaining/general-configuration/acra-translator.md#tls" >}}) flag,
+see its description for more on that.


### PR DESCRIPTION
* synchronized AT and AS guides
* added missing CLI flag for AT
* migrated general description about AT to acra-in-depth
* described what AS actually do in acra-in-depth as list