### PR TITLE
Update cli flags descriptions and deprecate acra-connector

### DIFF
--- a/acra/configuring-maintaining/general-configuration/acra-connector.md
+++ b/acra/configuring-maintaining/general-configuration/acra-connector.md
@@ -3,7 +3,7 @@ title: acra-connector
 weight: 5
 ---
 
-# acra-connector
+# acra-connector (deprecated since 0.91.0)
 
 ## Command line flags
 

--- a/acra/configuring-maintaining/general-configuration/acra-server.md
+++ b/acra/configuring-maintaining/general-configuration/acra-server.md
@@ -13,13 +13,13 @@ weight: 3
 
 * `--acraconnector_tls_transport_enable={true|false}`
 
-  Enable TLS to encrypt transport between AcraConnector and AcraServer.
+  Enable TLS to encrypt transport between AcraConnector and AcraServer (**deprecated since 0.91.0**, will be removed soon).
   Default is `false` which means "use SecureSession instead".
 
 * `--acraconnector_transport_encryption_disable={true|false}`
 
   Use raw transport (tcp/unix socket) between AcraTranslator and client app.
-  It turns off reading trace from client app's side which usually sent by AcraConnector.
+  It turns off reading trace from client app's side which usually sent by AcraConnector (**deprecated since 0.91.0**, will be removed soon).
   Default is `false`.
 
 * `--acrastruct_injectedcell_enable={true|false}`
@@ -78,7 +78,7 @@ weight: 3
 
 * `--securesession_id=<id>`
 
-  ID that will be sent during secure session handshake.
+  ID that will be sent during secure session handshake (**deprecated since 0.91.0**, will be removed soon).
   Default is `acra_server`.
 
 * `--sql_parse_on_error_exit_enable={true|false}`
@@ -323,7 +323,7 @@ weight: 3
 
 * `--acraconnector_tls_transport_enable={true|false}`
 
-  Enable TLS to encrypt transport between AcraConnector and AcraServer.
+  Enable TLS to encrypt transport between AcraConnector and AcraServer (**deprecated since 0.91.0**, will be removed soon).
   Default is `false` which means "use SecureSession instead".
 
 * `--tls_client_auth=<mode>`

--- a/acra/configuring-maintaining/general-configuration/acra-translator.md
+++ b/acra/configuring-maintaining/general-configuration/acra-translator.md
@@ -10,7 +10,7 @@ weight: 4
 * `--acraconnector_transport_encryption_disable={true|false}`
 
   Use raw transport (tcp/unix socket) between AcraTranslator and client app.
-  It turns off reading trace from client app's side which usually sent by AcraConnector.
+  It turns off reading trace from client app's side which usually sent by AcraConnector (**deprecated since 0.91.0**, will be removed soon).
   Default is `false`.
 
 * `--acratranslator_client_id_from_connection_enable={true|false}`
@@ -84,7 +84,7 @@ weight: 4
 
 * `--securesession_id=<id>`
 
-  ID that will be sent during secure session handshake.
+  ID that will be sent during secure session handshake (**deprecated since 0.91.0**, will be removed soon).
   Default is `acra_translator`.
 
 ### Configuration files
@@ -195,7 +195,7 @@ weight: 4
 
 * `--acratranslator_tls_transport_enable={true|false}`
 
-  Use TLS transport (tcp/unix socket) between AcraTranslator and client app.
+  Use TLS transport (tcp/unix socket) between AcraTranslator and client app (**deprecated since 0.91.0**, will be removed soon).
   Default is `false`.
 
 * `--tls_auth=<mode>`


### PR DESCRIPTION
Updated related page about deprecation according to https://github.com/cossacklabs/acra/pull/473.
Ready to view on `https://doc-lagovas....`.