### PR TITLE
Add info about `response_on_fail`

### DIFF
--- a/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
@@ -197,7 +197,7 @@ schemas:
       zone_id: "<string>" # [optional] [conflicts_with=client_id]
       crypto_envelope: "<acrablock|acrastruct>" # [optional]
       data_type: "<str|bytes|int32|int64>" # [optional] [conflicts_with=token_type|tokenized|consistent_tokenization]
-      response_on_fail: "<ciphertext|default_value|error>" # [optional] [required_with=data_type and]
+      response_on_fail: "<ciphertext|default_value|error>" # [optional] [required_with=data_type]
       default_data_value: "<string value>" # [optional] [required_with=data_type] may be string literal or valid int32/int64 yaml values
 
       # Tokenization

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
@@ -349,7 +349,7 @@ Type: `ciphertext`, `default_value`, `error`
 Depends on: `data_type`
 
 <!-- TODO: is it correct? -->
-Group: `encryption`, `searchable encryption`, `masking` (`int32`, `int64` not supported for masking)
+Group: `encryption`, `searchable encryption`, `masking`
 
 Descryption: specifies which action should be performed in case of a failure of some operation (decryption error, wrong data type, etc.).
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
@@ -348,7 +348,6 @@ Type: `ciphertext`, `default_value`, `error`
 
 Depends on: `data_type`
 
-<!-- TODO: is it correct? -->
 Group: `encryption`, `searchable encryption`, `masking`
 
 Descryption: specifies which action should be performed in case of a failure of some operation (decryption error, wrong data type, etc.).

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/encryptor-config.md
@@ -357,7 +357,7 @@ The `ciphertext` means that the raw (possibly encrypted) data should be returned
 
 The `default_value` requires `default_data_value` and specifies that some default value should be returned instead.
 
-The `error` will produce a db-specific error, which could be handled on the client side. The message will look like `encoding error in "column_name"`.
+The `error` will produce a db-specific error, which could be handled on the client side. The message will look like `encoding error in "<column_name>"`.
 
 If not specified, the default value for `response_on_fail` is `ciphertext`, unless `default_data_value` is defined. In that case, the `response_on_fail` would implicitly become `default_value`:
 


### PR DESCRIPTION
This PR updates docs and introduces a new `response_on_fail` field into the settings, which was brought up in the https://github.com/cossacklabs/acra/pull/521. 