### PR TITLE
Replace v2 keystore with v1 in examples

### DIFF
--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -90,11 +90,11 @@ For example, lets generate several transport keys using [`generate`]({{< ref "/a
 
 {{< hint info >}}
 **Note:**
-Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v2`.
+Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v1`.
 {{< /hint >}}
 
 ```
-$ acra-keys generate --client_id=user1 --keystore=v2 --acraconnector_transport_key --acraserver_transport_key
+$ acra-keys generate --client_id=user1 --keystore=v1 --acraconnector_transport_key --acraserver_transport_key
 
 INFO[0000] Initializing ACRA_MASTER_KEY loader...       
 INFO[0000] Initialized default env ACRA_MASTER_KEY loader 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -5,7 +5,7 @@ weight: 1
 
 # list
 
-**`list`** is `acra-keys` subcommand used for describing keys of the keystore version `v2`.
+**`list`** is `acra-keys` subcommand used for describing keys of the keystore versions `v1|v2`.
 
 ## Command line flags
 
@@ -84,15 +84,15 @@ weight: 1
 
 ## Usage example
 
-Using **`list`** subcommand of `acra-keys` you can get the description about keys stored in `v2` keystore.
-For example, lets generate several keys using [`generate`]({{< ref "/acra/configuring-maintaining/general-configuration/acra-keys/generate" >}}) subcommand:
+Using **`list`** subcommand of `acra-keys` you can get the description about keys stored in a keystore.
+For example, let's generate several keys using [`generate`]({{< ref "/acra/configuring-maintaining/general-configuration/acra-keys/generate" >}}) subcommand:
 
 {{< hint info >}}
 **Note:**
-Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v2`.
+Make sure you have set `ACRA_MASTER_KEY` env variable for the keystore `v1`.
 {{< /hint >}}
 ```
-$ acra-keys generate --client_id=user1 --keystore=v2 --client_storage_symmetric_key --audit_log_symmetric_key
+$ acra-keys generate --client_id=user1 --keystore=v1 --client_storage_symmetric_key --audit_log_symmetric_key
 
 INFO[0000] Initializing ACRA_MASTER_KEY loader...       
 INFO[0000] Initialized default env ACRA_MASTER_KEY loader 
@@ -107,9 +107,10 @@ $ acra-keys list
 
 INFO[0000] Initializing ACRA_MASTER_KEY loader...       
 INFO[0000] Initialized default env ACRA_MASTER_KEY loader 
-Key purpose                  | Client/Zone ID | Key ID
------------------------------+----------------+-------------------------
-audit log signature key      |                | audit-log
-client storage symmetric key | user1          | client/user1/storage-sym
+Key purpose     | Client/Zone ID | Key ID
+----------------+----------------+------------------
+audit_log       | secure         | secure_log_key
+storage_sym_key | user1          | user1_storage_sym
+audit_log       | secure         | secure_log_key
+storage_sym_key | user1          | user1_storage_sym
 ```
-

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -109,8 +109,6 @@ INFO[0000] Initializing ACRA_MASTER_KEY loader...
 INFO[0000] Initialized default env ACRA_MASTER_KEY loader 
 Key purpose     | Client/Zone ID | Key ID
 ----------------+----------------+------------------
-audit_log       | secure         | secure_log_key
-storage_sym_key | user1          | user1_storage_sym
-audit_log       | secure         | secure_log_key
+audit_log       |                | secure_log_key
 storage_sym_key | user1          | user1_storage_sym
 ```

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -97,11 +97,11 @@ For example, lets generate storage keys using [`generate`]({{< ref "/acra/config
 
 {{< hint info >}}
 **Note:**
-Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v2`.
+Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v1`.
 {{< /hint >}}
 
 ```
-$ acra-keys generate --client_id=user1 --keystore=v2 --client_storage_key
+$ acra-keys generate --client_id=user1 --keystore=v1 --client_storage_key
 
 INFO[0000] Initializing ACRA_MASTER_KEY loader...       
 INFO[0000] Initialized default env ACRA_MASTER_KEY loader 

--- a/content/acra/configuring-maintaining/general-configuration/acra-translator.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-translator.md
@@ -290,7 +290,7 @@ Required for encrypt/decrypt requests.
 
 ```
 acra-keymaker \
-    --keystore=v2 \
+    --keystore=v1 \
     --client_id=client1 \
     --generate_acrawriter_key \
     --keys_output_dir=/tmp/translator_keys
@@ -306,7 +306,7 @@ Used in `AcraConnector ↔︎ AcraTranslator` connection with `SecureSession` as
 
 ```
 acra-keymaker \
-    --keystore=v2 \
+    --keystore=v1 \
     --client_id=client1 \
     --generate_acratranslator_keys \
     --keys_output_dir=/tmp/translator_keys
@@ -319,7 +319,7 @@ Required for hashing requests, as well as searchable encryption/decryption.
 
 ```
 acra-keymaker \
-    --keystore=v2 \
+    --keystore=v1 \
     --client_id=client1 \
     --generate_hmac_key \
     --keys_output_dir=/tmp/translator_keys
@@ -331,7 +331,7 @@ Required for tokenization/detokenization requests.
 
 ```
 acra-keymaker \
-    --keystore=v2 \
+    --keystore=v1 \
     --client_id=client1 \
     --generate_symmetric_storage_key \
     --keys_output_dir=/tmp/translator_keys


### PR DESCRIPTION
This PR updates docs and changes suggestions and examples to use keystore v1 due to better performance.

