### PR TITLE
Fix postgresql debugging section

### DIFF
--- a/content/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
+++ b/content/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
@@ -90,7 +90,7 @@ COMMIT
 
 Though most of the db-drivers do an explicit `ROLLBACK` in case of an error, so it should not be a problem.
 
-## Data types
+### Data types
 
 AcraServer only supports storing AcraStructs/AcraBlocks in `bytea` column types and supports 3 types of binary data encoding from PostgreSQL:
 [hex](https://www.postgresql.org/docs/current/datatype-binary.html#AEN5755),

--- a/content/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
+++ b/content/acra/configuring-maintaining/debugging-and-troubleshooting/_index.md
@@ -90,7 +90,7 @@ COMMIT
 
 Though most of the db-drivers do an explicit `ROLLBACK` in case of an error, so it should not be a problem.
 
-### Data types
+### PostgreSQL data types
 
 AcraServer only supports storing AcraStructs/AcraBlocks in `bytea` column types and supports 3 types of binary data encoding from PostgreSQL:
 [hex](https://www.postgresql.org/docs/current/datatype-binary.html#AEN5755),


### PR DESCRIPTION
This includes:
- Fix header level (third instead of second)
- Returning old name of the header ("PostgreSQL data type" instead of "Data types")