### PR TITLE
Add keystore_encryption_type flag info

### DIFF
--- a/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
@@ -66,7 +66,7 @@ weight: 10
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
     via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
@@ -60,6 +60,18 @@ weight: 10
 
   Password to Redis database.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
 
 ### KMS
 
@@ -78,6 +90,11 @@ weight: 10
   ```json
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 
 ### HashiCorp Vault
@@ -116,6 +133,11 @@ weight: 10
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
   
 ## Output
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-backup.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-backup.md
@@ -77,7 +77,7 @@ weight: 9
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
     via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-backup.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-backup.md
@@ -71,6 +71,18 @@ weight: 9
 
   Password to Redis database.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+
 
 ### KMS
 
@@ -89,6 +101,11 @@ weight: 9
   ```json
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 
 #### HashiCorp Vault
@@ -127,6 +144,11 @@ weight: 9
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 
 🔴 - flags required to be specified.

--- a/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -87,6 +87,18 @@ By default, certificate Distinguished Name is used as ClientID.
   Output file is `configs/markdown_acra-keymaker.md`.
   Works in a pair with `--dump_config`.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create corresponded key-encryption keys on KMS if not present on KMS.
 
 ### KMS
 
@@ -114,6 +126,10 @@ By default, certificate Distinguished Name is used as ClientID.
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 ### HashiCorp Vault
 
@@ -151,7 +167,12 @@ By default, certificate Distinguished Name is used as ClientID.
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
-  
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
+
 ## Generating keys
 
 {{< hint warning >}}

--- a/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -93,7 +93,7 @@ By default, certificate Distinguished Name is used as ClientID.
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
     via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -63,6 +63,10 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 #### HashiCorp Vault
 
@@ -101,6 +105,10 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 ## Usage example
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -45,6 +45,21 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
 
   Password to Redis database.
 
+
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
+
+
 ### KMS
 
 * `--kms_type=<type>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
@@ -73,6 +73,10 @@ weight: 4
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 #### HashiCorp Vault
 
@@ -110,6 +114,11 @@ weight: 4
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
   🔴 - flags required to be specified.
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -87,6 +87,11 @@ weight: 2
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
+
 ### HashiCorp Vault
 
 `acra-keys` can read `ACRA_MASTER_KEY` from HashiCorp Vault instead of environment variable.
@@ -123,6 +128,11 @@ weight: 2
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 ## Generating keys
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -69,6 +69,20 @@ weight: 2
 
   Password to Redis database.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
+
+
 ### KMS
 
 * `--kms_type=<type>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
@@ -56,6 +56,19 @@ weight: 5
 
   Password to Redis database.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
+
 ### KMS
 
 * `--kms_type=<type>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
@@ -74,6 +74,10 @@ weight: 5
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 #### HashiCorp Vault
 
@@ -111,6 +115,11 @@ weight: 5
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
   🔴 - flags required to be specified.
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -59,6 +59,11 @@ weight: 1
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
+
 
 #### HashiCorp Vault
 
@@ -96,6 +101,11 @@ weight: 1
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
   🔴 - flags required to be specified.
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -41,6 +41,20 @@ weight: 1
 
   Password to Redis database.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
+
+
 ### KMS
 
 * `--kms_type=<type>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
@@ -76,6 +76,10 @@ weight: 6
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 #### HashiCorp Vault
 
@@ -113,6 +117,11 @@ weight: 6
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
   🔴 - flags required to be specified.
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
@@ -58,15 +58,28 @@ weight: 6
 
   Password to Redis database.
 
+### Keystore
+
+* `--{src|dst}_keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
+
 ### KMS
 
-* `--kms_type=<type>`
+* `--{src|dst}_kms_type=<type>`
 
   Specify your KMS.
   Currently supported KMS types:
   * `aws` - AWS Key Management Service
 
-* `--kms_credentials_path=<filepath>`
+* `--{src|dst}_kms_credentials_path=<filepath>`
 
   A path to a file with KMS credentials JSON format.
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -50,6 +50,19 @@ weight: 3
 
   Password to Redis database.
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+    Create new KMS zone key-encryption key if not present on KMS.
+
 ### KMS
 
 * `--kms_type=<type>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -68,6 +68,11 @@ weight: 3
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
+
 #### HashiCorp Vault
 
 `acra-keys` can read `ACRA_MASTER_KEY` from HashiCorp Vault instead of environment variable.
@@ -104,6 +109,11 @@ weight: 3
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
   🔴 - flags required to be specified.
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
@@ -111,7 +111,7 @@ It expects symmetric key to decrypt keys from keystore from  `ACRA_MASTER_KEY` e
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
     via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
@@ -107,6 +107,16 @@ It expects symmetric key to decrypt keys from keystore from  `ACRA_MASTER_KEY` e
 
   Password to Redis database.
 
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+
 
 ### KMS
 
@@ -125,6 +135,11 @@ It expects symmetric key to decrypt keys from keystore from  `ACRA_MASTER_KEY` e
   ```json
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
   
 
 ### HashiCorp Vault
@@ -161,6 +176,11 @@ It expects symmetric key to decrypt keys from keystore from  `ACRA_MASTER_KEY` e
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
   
 ## Usage example
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
@@ -57,7 +57,7 @@ weight: 11
 
   Keystore encryption strategy.
   Currently supported strategies:
-    * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+    * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
     * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
     * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
       via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
@@ -51,6 +51,20 @@ weight: 11
   Password to Redis database.
 
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+    * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+    * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+    * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+      via KMS key-encryption key.
+    * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+      Create corresponded key-encryption key on KMS if not present on KMS.
+
+
 ### KMS
 
 * `--kms_type=<type>`
@@ -69,6 +83,10 @@ weight: 11
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 ### HashiCorp Vault
 
@@ -101,6 +119,11 @@ weight: 11
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 ## Usage
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
@@ -92,6 +92,19 @@ Rollback utility especially applicable in case of any DB rollback - keys re-gene
   Password to Redis database.
 
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** - Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and
+    decrypted via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+
+
 ### KMS
 
 * `--kms_type=<type>`
@@ -110,6 +123,10 @@ Rollback utility especially applicable in case of any DB rollback - keys re-gene
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 ### HashiCorp Vault
 
@@ -147,6 +164,11 @@ Rollback utility especially applicable in case of any DB rollback - keys re-gene
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 ## Usage example
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
@@ -98,7 +98,7 @@ Rollback utility especially applicable in case of any DB rollback - keys re-gene
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** - Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and
     decrypted via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
@@ -104,7 +104,7 @@ weight: 8
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** - Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and
     decrypted via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
@@ -98,6 +98,19 @@ weight: 8
   Password to Redis database.
 
 
+### Keystore
+
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** - Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and
+    decrypted via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+
+
 ### KMS
 
 * `--kms_type=<type>`
@@ -116,6 +129,10 @@ weight: 8
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 #### HashiCorp Vault
 
@@ -154,6 +171,10 @@ weight: 8
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 ## Usage example
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -224,7 +224,7 @@ weight: 3
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
     via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -1,4 +1,4 @@
----
+_---
 title: acra-server
 weight: 3
 ---
@@ -220,6 +220,17 @@ weight: 3
   Currently, supported only for keystore `v1` and will fail to start for keystore `v2`.
   Default is `true`.
 
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** -  Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and decrypted
+    via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+
+
 ### MySQL
 
 * `--mysql_enable={true|false}`
@@ -437,6 +448,11 @@ For additional certificate validation flags, see corresponding pages:
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
 
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
+
 ### Hashicorp Vault
 
 * `--vault_connection_api_string=<url>`
@@ -468,6 +484,11 @@ For additional certificate validation flags, see corresponding pages:
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 
   🔴 - flags required to be specified.
@@ -565,4 +586,4 @@ AcraWebConfig and AcraAuthManager are deprecated and will not be available since
 
 There are a couple of signals `acra-server` reacts on:
 - `SIGTERM`, `SIGINT` — graceful shutdown: stop accepting new connections, close existing ones, terminate the process.
-- `SIGHUP` — restart: create new AcraServer subprocess and transfer opened listener sockets to it, then terminate the current process.
+- `SIGHUP` — restart: create new AcraServer subprocess and transfer opened listener sockets to it, then terminate the current process._

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -586,4 +586,4 @@ AcraWebConfig and AcraAuthManager are deprecated and will not be available since
 
 There are a couple of signals `acra-server` reacts on:
 - `SIGTERM`, `SIGINT` — graceful shutdown: stop accepting new connections, close existing ones, terminate the process.
-- `SIGHUP` — restart: create new AcraServer subprocess and transfer opened listener sockets to it, then terminate the current process._
+- `SIGHUP` — restart: create new AcraServer subprocess and transfer opened listener sockets to it, then terminate the current process.

--- a/content/acra/configuring-maintaining/general-configuration/acra-translator.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-translator.md
@@ -247,7 +247,7 @@ For additional certificate validation flags, see corresponding pages:
 
   Keystore encryption strategy.
   Currently supported strategies:
-  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`env_master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
   * **`vault_master_key`** - Keystore using Acra Master Key, loaded from Hashicorp Vault
   * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and
     decrypted via KMS key-encryption key.

--- a/content/acra/configuring-maintaining/general-configuration/acra-translator.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-translator.md
@@ -243,6 +243,17 @@ For additional certificate validation flags, see corresponding pages:
 [CRL](/acra/configuring-maintaining/tls/crl/).
 
 
+* `--keystore_encryption_type=<strategy>`
+
+  Keystore encryption strategy.
+  Currently supported strategies:
+  * **`master_key`** (**Default**) - Keystore using Acra Master Key, loaded from ENV (`ACRA_MASTER_KEY`) variable;
+  * **`vault_master_key`** - Keystore using Acra Master Key, loaded from Hashicorp Vault
+  * **`kms_encrypted_master_key`** - Keystore using Acra Master Key, loaded from ENV `ACRA_MASTER_KEY` variable and
+    decrypted via KMS key-encryption key.
+  * **`kms_per_client`** - Keystore using KMS for decryption Acra keys per ClientID and ZoneID.
+
+
 ### KMS
 
 * `--kms_type=<type>`
@@ -260,7 +271,11 @@ For additional certificate validation flags, see corresponding pages:
   ```json
      {"access_key_id":"<access_key_id>","secret_access_key":"<secret_access_key>","region":"<region>"}
   ```
-  
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_key|kms_per_client>` flags.
+{{< /hint >}}
 
 ### HashiCorp Vault
 
@@ -293,6 +308,11 @@ For additional certificate validation flags, see corresponding pages:
 
   Use TLS to encrypt transport with HashiCorp Vault.
   Default is `false`.
+
+{{< hint info >}}
+**Note**:
+Should be provided only with `--keystore_encryption_type=<vault_master_key>` flag.
+{{< /hint >}}
 
 ## Keys
 


### PR DESCRIPTION
Added `keystore_encryption_type` flag definition across acra-tools. 

Open question to discuss whether we need to specify what names of KEKs will be used during the creation of KMS keys.
Like:
- ClientKeys -> `acra_<clientID>`,
- ZoneKeys -> `zone_<zoneID>`.
- PoisonRecordsKeys -> `acra_poison`
......

Currently, I only mentioned that corresponded KEKs will be created if not present on KMS.
