### PR TITLE
Add info about joins in searchable queries

### DIFF
--- a/content/acra/security-controls/searchable-encryption/_index.md
+++ b/content/acra/security-controls/searchable-encryption/_index.md
@@ -71,7 +71,7 @@ SELECT ... FROM ... WHERE substring(searchable_column, 1, <HMAC_size>) = $1
 ```
 
 {{< hint info >}}
-Due to MySQL have ambiguous behaviour with filtering over binary data in text format, for MySQL added explicit casting search hash to bytes:
+Due to MySQL has ambiguous behaviour with filtering over binary data in text format, for MySQL added explicit casting search hash to bytes:
 
 ```
 SELECT ... FROM ... WHERE convert(substr(searchable_column, ...), binary) = 0xFFFFF


### PR DESCRIPTION
Added info block about the latest changes in Acra related to [supporting JOIN](https://github.com/cossacklabs/acra/pull/592) in searchable queries. 

Also, added examples of under-the-hood representation and query modification during searchable encryption requested by @Lagovas https://github.com/cossacklabs/product-docs/pull/274#discussion_r1002069906