### PR TITLE
Update tls flags [forked]

### DIFF
--- a/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
@@ -168,7 +168,7 @@ weight: 10
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
@@ -130,7 +130,7 @@ weight: 10
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-addzone.md
@@ -64,7 +64,7 @@ weight: 10
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -80,8 +80,8 @@ weight: 10
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
-  Empty by default.
+  Path to TLS certificate presented to Redis.
+  Empty by default. 
 
 
 * `--redis_tls_client_key=<filename>`
@@ -130,7 +130,7 @@ weight: 10
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -168,7 +168,7 @@ weight: 10
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -177,8 +177,7 @@ weight: 10
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -262,19 +261,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-addzone TLS certificate's CA certificate for Vault certificate validation (acra-addzone works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-addzone TLS certificate presented to Vault (acra-addzone works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-addzone TLS certificate's private key of the TLS certificate presented to Vault (acra-addzone works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -357,8 +356,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-authmanager.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-authmanager.md
@@ -110,19 +110,19 @@ read an encrypted file with authentication data.
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-authmanager TLS certificate's CA certificate for Vault certificate validation (acra-authmanager works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-authmanager TLS certificate presented to Vault (acra-authmanager works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-authmanager TLS certificate's private key of the TLS certificate presented to Vault (acra-authmanager works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -205,8 +205,7 @@ read an encrypted file with authentication data.
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-backup.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-backup.md
@@ -146,19 +146,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-backup TLS certificate's CA certificate for Vault certificate validation (acra-backup works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-backup TLS certificate presented to Vault (acra-backup works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-backup TLS certificate's private key of the TLS certificate presented to Vault (acra-backup works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -235,15 +235,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   "URL from configuration" above means the one configured with `--vault_tls_ocsp_client_url` flags.
 
 
+* `--vault_tls_ocsp_client_required=<policy>`
 
   How to handle situation when OCSP server doesn't know about requested Vault certificate and returns "Unknown".
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
-* `--vault_tls_ocsp_client_required=<policy>`
 
 * `--vault_tls_ocsp_client_url=<url>`
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -140,7 +140,7 @@ By default, certificate Distinguished Name is used as ClientID.
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -178,7 +178,7 @@ By default, certificate Distinguished Name is used as ClientID.
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keymaker.md
@@ -74,7 +74,7 @@ By default, certificate Distinguished Name is used as ClientID.
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -90,7 +90,7 @@ By default, certificate Distinguished Name is used as ClientID.
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -140,7 +140,7 @@ By default, certificate Distinguished Name is used as ClientID.
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -178,7 +178,7 @@ By default, certificate Distinguished Name is used as ClientID.
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -187,8 +187,7 @@ By default, certificate Distinguished Name is used as ClientID.
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -296,19 +295,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keymaker TLS certificate's CA certificate for Vault certificate validation (acra-keymaker works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keymaker TLS certificate presented to Vault (acra-keymaker works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keymaker TLS certificate's private key of the TLS certificate presented to Vault (acra-keymaker works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -391,8 +390,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -115,7 +115,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -49,7 +49,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -65,7 +65,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -115,7 +115,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -153,7 +153,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -162,8 +162,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -250,19 +249,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's CA certificate for Vault certificate validation (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's private key of the TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -345,8 +344,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -153,7 +153,7 @@ Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will 
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
@@ -125,7 +125,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
@@ -59,7 +59,7 @@ weight: 4
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -75,7 +75,7 @@ weight: 4
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -125,7 +125,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -163,7 +163,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -172,8 +172,7 @@ weight: 4
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -245,19 +244,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's CA certificate for Vault certificate validation (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's private key of the TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -340,8 +339,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/export.md
@@ -163,7 +163,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -73,7 +73,7 @@ weight: 2
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -89,7 +89,7 @@ weight: 2
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -139,7 +139,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -177,7 +177,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -186,8 +186,7 @@ weight: 2
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -273,19 +272,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's CA certificate for Vault certificate validation (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's private key of the TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -368,8 +367,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -177,7 +177,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/generate.md
@@ -139,7 +139,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
@@ -126,7 +126,7 @@ weight: 5
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
@@ -164,7 +164,7 @@ weight: 5
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/import.md
@@ -60,7 +60,7 @@ weight: 5
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -76,7 +76,7 @@ weight: 5
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -126,7 +126,7 @@ weight: 5
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -164,7 +164,7 @@ weight: 5
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -173,8 +173,7 @@ weight: 5
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -259,19 +258,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's CA certificate for Vault certificate validation (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's private key of the TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -354,8 +353,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -149,7 +149,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -111,7 +111,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/list.md
@@ -45,7 +45,7 @@ weight: 1
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -61,7 +61,7 @@ weight: 1
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -111,7 +111,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -149,7 +149,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -158,8 +158,7 @@ weight: 1
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -238,21 +237,27 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
 
+* `--vault_tls_ca_path=<filename>`
+
+  Path to CA certificate for HashiCorp Vault certificate validation.
+  Default is empty (deprecated since 0.94.0, use `vault_tls_client_ca` instead).
+
+
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's CA certificate for Vault certificate validation (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's private key of the TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -335,8 +340,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
@@ -78,7 +78,7 @@ weight: 6
 
 * `--{src|dst}_redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis (acra-keys works as "client" when communicating with Redis).
   Empty by default.
 
 
@@ -265,7 +265,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--{src|dst}_vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/migrate.md
@@ -166,7 +166,7 @@ weight: 6
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--{src|dst}_redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--{src|dst}_redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -120,7 +120,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -158,7 +158,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/read.md
@@ -54,7 +54,7 @@ weight: 3
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -70,7 +70,7 @@ weight: 3
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -120,7 +120,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -158,7 +158,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -167,8 +167,7 @@ weight: 3
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -253,19 +252,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's CA certificate for Vault certificate validation (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-keys TLS certificate's private key of the TLS certificate presented to Vault (acra-keys works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -348,8 +347,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-log-verifier.md
@@ -181,19 +181,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-log-verifier TLS certificate's CA certificate for Vault certificate validation (acra-log-verifier works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-log-verifier TLS certificate presented to Vault (acra-log-verifier works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-log-verifier TLS certificate's private key of the TLS certificate presented to Vault (acra-log-verifier works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -276,8 +276,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
@@ -241,7 +241,7 @@ Should be provided only with `--keystore_encryption_type=<vault_master_key>` fla
 In general, this tool is used like this:
 
 1) Generate "poison keys" using one of
-   * `acra-poisonrecordmaker generate --keystore=vX --poison_record_keys`
+   * `acra-keys generate --keystore=vX --poison_record_keys`
    * `acra-keymaker --keystore=vX --generate_poisonrecord_keys`
 
 2) Use this tool to generate the poison record itself:

--- a/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-poisonrecordmaker.md
@@ -111,11 +111,11 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   Set authentication mode that will be used for TLS connection with Vault.
 
-    * `0` — do not request client certificate, ignore it if received;
-    * `1` — request client certificate, but don't require it;
-    * `2` — expect to receive at least one certificate to continue the handshake;
-    * `3` — don't require client certificate, but validate it if client actually sent it;
-    * `4` — (default) request and validate client certificate.
+  * `0` — do not request client certificate, ignore it if received;
+  * `1` — request client certificate, but don't require it;
+  * `2` — expect to receive at least one certificate to continue the handshake;
+  * `3` — don't require client certificate, but validate it if client actually sent it;
+  * `4` — (default) request and validate client certificate.
 
   These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
 
@@ -127,19 +127,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-poisonrecordmaker TLS certificate's CA certificate for Vault certificate validation (acra-poisonrecordmaker works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-poisonrecordmaker TLS certificate presented to Vault (acra-poisonrecordmaker works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-poisonrecordmaker TLS certificate's private key of the TLS certificate presented to Vault (acra-poisonrecordmaker works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -166,8 +166,8 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   This flag controls behavior of validator in cases when Vault certificate chain contains at least one intermediate certificate.
 
-    * `true` — validate only leaf certificate
-    * `false` — (default) validate leaf certificate and all intermediate certificates
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
 
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
@@ -178,10 +178,10 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   How to treat CRL's URL described in a certificate from Vault server/agent
 
-    * `use` — try URL(s) from certificate after the one from configuration (if set)
-    * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
-    * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
-    * `ignore` — completely ignore CRL's URL(s) specified in certificate
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--vault_tls_crl_client_url` flags.
 
@@ -196,8 +196,8 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   This flag controls behavior of validator in cases when Vault certificate chain contains at least one intermediate certificate.
 
-    * `true` — validate only leaf certificate
-    * `false` — (default) validate leaf certificate and all intermediate certificates
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
 
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
@@ -208,10 +208,10 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   How to treat OCSP server URL described in a certificate from Vault server.
 
-    * `use` — try URL(s) from certificate after the one from configuration (if set)
-    * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
-    * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
-    * `ignore` — completely ignore OCSP's URL(s) specified in certificate
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--vault_tls_ocsp_client_url` flags.
 
@@ -241,7 +241,7 @@ Should be provided only with `--keystore_encryption_type=<vault_master_key>` fla
 In general, this tool is used like this:
 
 1) Generate "poison keys" using one of
-   * `acra-keys generate --keystore=vX --poison_record_keys`
+   * `acra-poisonrecordmaker generate --keystore=vX --poison_record_keys`
    * `acra-keymaker --keystore=vX --generate_poisonrecord_keys`
 
 2) Use this tool to generate the poison record itself:

--- a/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
@@ -172,19 +172,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-rollback TLS certificate's CA certificate for Vault certificate validation (acra-rollback works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-rollback TLS certificate presented to Vault (acra-rollback works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-rollback TLS certificate's private key of the TLS certificate presented to Vault (acra-rollback works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -267,8 +267,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
@@ -101,7 +101,7 @@ weight: 8
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -117,7 +117,7 @@ weight: 8
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -167,7 +167,7 @@ weight: 8
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -205,7 +205,7 @@ weight: 8
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -214,8 +214,7 @@ weight: 8
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`
@@ -285,8 +284,11 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   Set authentication mode that will be used for TLS connection with Vault.
 
-  Path to additional CA certificate for Vault certificate validation.
-  Empty by default.
+  * `0` — do not request client certificate, ignore it if received;
+  * `1` — request client certificate, but don't require it;
+  * `2` — expect to receive at least one certificate to continue the handshake;
+  * `3` — don't require client certificate, but validate it if client actually sent it;
+  * `4` — (default) request and validate client certificate.
 
   These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
 
@@ -298,19 +300,19 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to acra-rotate TLS certificate's CA certificate for Vault certificate validation (acra-rotate works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-rotate TLS certificate presented to Vault (acra-rotate works as "client" when communicating with Vault).
   Empty by default.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to acra-rotate TLS certificate's private key of the TLS certificate presented to Vault (acra-rotate works as "client" when communicating with Vault).
   Empty by default.
 
 
@@ -393,8 +395,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--vault_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
@@ -167,7 +167,7 @@ weight: 8
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
@@ -205,7 +205,7 @@ weight: 8
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -162,7 +162,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
   If not specified, AcraServer uses value from `--tls_crl_from_cert` flag.
 
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -100,20 +100,23 @@ weight: 3
 
 * `--redis_tls_client_ca=<filename>`
 
-  Path to additional CA certificate for Redis' certificate validation (overrides `--tls_ca`).
+  Path to additional CA certificate for Redis' certificate validation.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ca` flag.
 
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to server TLS certificate presented to Redis (overrides `--tls_cert`).
+  Path to TLS certificate presented to Redis.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_cert` flag.
 
 
 * `--redis_tls_client_key=<filename>`
 
-  Path to private key of the TLS certificate presented to Redis (overrides `--tls_key`).
+  Path to private key of the TLS certificate presented to Redis.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_key` flag.
 
 
 * `--redis_tls_client_sni=<SNI>`
@@ -127,12 +130,14 @@ weight: 3
   How many CRLs to cache in memory in connections to Redis.
   Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
   Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+  If not specified, AcraServer uses value from `--tls_crl_cache_size` flag.
 
 
 * `--redis_tls_crl_client_cache_time=<seconds>`
 
   How long to keep CRLs cached, in seconds for connections to Redis.
   Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+  If not specified, AcraServer uses value from `--tls_crl_cache_time` flag.
 
 
 * `--redis_tls_crl_client_check_only_leaf_certificate={true|false}`
@@ -145,6 +150,7 @@ weight: 3
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+  If not specified, AcraServer uses value from `--tls_crl_check_only_leaf_certificate` flag.
 
 
 * `--redis_tls_crl_client_from_cert=<policy>`
@@ -157,12 +163,14 @@ weight: 3
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  If not specified, AcraServer uses value from `--tls_crl_from_cert` flag.
 
 
 * `--redis_tls_crl_client_url=<url>`
 
   CRL's URL for outcoming TLS connections to Redis.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_crl_url` flag.
 
 
 * `--redis_tls_enable=<true|false>`
@@ -183,6 +191,7 @@ weight: 3
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know whom to ask about them.
+  If not specified, AcraServer uses value from `--tls_ocsp_check_only_leaf_certificate` flag.
 
 
 * `--redis_tls_ocsp_client_from_cert=<policy>`
@@ -195,6 +204,7 @@ weight: 3
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  If not specified, AcraServer uses value from `--tls_ocsp_from_cert` flag.
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -203,14 +213,15 @@ weight: 3
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  If not specified, AcraServer uses value from `--tls_ocsp_required` flag.
 
 
 * `--redis_tls_ocsp_client_url=<url>`
 
   OCSP service URL for outgoing TLS connections to check Redis' certificates.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ocsp_url` flag.
 
 * `--securesession_id=<id>`
 
@@ -495,23 +506,24 @@ weight: 3
   Possible values are the same as for `--tls_auth`.
   Default is `-1` which means "take value of `--tls_auth`".
 
-  Overrides the `--tls_auth` setting.
-
 * `--tls_client_key=<filename>`
 
   Path to private key of the TLS certificate presented to applications/AcraConnectors (see `--tls_client_cert`).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_key` flag.
 
 * `--tls_client_cert=<filename>`
 
-  Path to server TLS certificate presented to applications/AcraConnectors (overrides `--tls_cert`).
+  Path to TLS certificate presented to applications/AcraConnectors.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_cert` flag.
 
 * `--tls_client_ca=<filename>`
 
   Path to additional CA certificate for application/AcraConnector certificate validation
   (setup if CA certificate of application/AcraConnector is different from CA certificate of database).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ca` flag.
 
 * `--tls_client_id_from_cert={true|false}`
 
@@ -525,7 +537,6 @@ weight: 3
 
   Set authentication mode that will be used for TLS connection with a database.
   Possible values are the same as for `--tls_auth`.
-  Overrides the `--tls_auth` setting.
   Default is `-1` which means "take value of `--tls_auth`".
 
 * `--tls_database_key=<filename>`
@@ -533,17 +544,20 @@ weight: 3
   Path to private key that will be used for TLS handshake with a database.
   Should correspond to the certificate configured with `--tls_database_cert`.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_key` flag.
 
 * `--tls_database_cert=<filename>`
 
-  Path to client TLS certificate shown to database during TLS handshake (overrides `--tls_cert`).
+  Path to client TLS certificate shown to database during TLS handshake.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_cert` flag.
 
 * `--tls_database_ca=<filename>`
 
   Path to additional CA certificate for database certificate validation
   (setup if CA certificate of database is different from CA certificate of application/AcraConnector).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ca` flag.
 
 * `--tls_database_sni=<SNI>`
 
@@ -613,23 +627,27 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `4` — (default) request and validate client certificate.
 
   These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
+  If not specified, AcraServer uses value from `--tls_auth` flag.
 
 * `--consul_tls_client_ca=<filename>`
 
   Path to additional CA certificate for Consul certificate validation.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ca` flag.
 
 
 * `--consul_tls_client_cert=<filename>`
 
   Path to AcraServer TLS certificate presented to Consul (AcraServer works as "client" when communicating with Consul).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_cert` flag.
 
 
 * `--consul_tls_client_key=<filename>`
 
   Path to private key of the TLS certificate presented to Consul.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_key` flag.
 
 
 * `--consul_tls_client_sni=<SNI>`
@@ -643,12 +661,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   How many CRLs to cache in memory in connections to Consul.
   Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
   Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+  If not specified, AcraServer uses value from `--tls_crl_cache_size` flag.
 
 
 * `--consul_tls_crl_client_cache_time=<seconds>`
 
   How long to keep CRLs cached, in seconds for connections to Consul.
   Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+  If not specified, AcraServer uses value from `--tls_crl_cache_time` flag.
 
 
 * `--consul_tls_crl_client_check_only_leaf_certificate={true|false}`
@@ -661,6 +681,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+  If not specified, AcraServer uses value from `--tls_crl_check_only_leaf_certificate` flag.
 
 
 * `--consul_tls_crl_client_from_cert=<policy>`
@@ -673,12 +694,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--consul_tls_crl_client_url` flags.
+  If not specified, AcraServer uses value from `--tls_crl_from_cert` flag.
 
 
 * `--consul_tls_crl_client_url=<url>`
 
   CRL's URL for outcoming TLS connections to Consul.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_crl_url` flag.
 
 
 * `--consul_tls_enable=<true|false>`
@@ -699,6 +722,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know whom to ask about them.
+  If not specified, AcraServer uses value from `--tls_ocsp_check_only_leaf_certificate` flag.
 
 
 * `--consul_tls_ocsp_client_from_cert=<policy>`
@@ -711,6 +735,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--consul_tls_ocsp_client_url` flags.
+  If not specified, AcraServer uses value from `--tls_ocsp_from_cert` flag.
 
 
 * `--consul_tls_ocsp_client_required=<policy>`
@@ -719,14 +744,15 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  If not specified, AcraServer uses value from `--tls_ocsp_required` flag.
 
 
 * `--consul_tls_ocsp_client_url=<url>`
 
   OCSP service URL for outgoing TLS connections to check Consuls' certificates.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ocsp_url` flag.
 
 
 ### Hashicorp Vault
@@ -759,6 +785,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `4` — (default) request and validate client certificate.
 
   These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
+  If not specified, AcraServer uses value from `--tls_auth` flag.
 
 * `--vault_tls_ca_path=<filename>`
 
@@ -770,18 +797,21 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ca` flag.
 
 
 * `--vault_tls_client_cert=<filename>`
 
   Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_cert` flag.
 
 
 * `--vault_tls_client_key=<filename>`
 
   Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_key` flag.
 
 
 * `--vault_tls_client_sni=<SNI>`
@@ -795,12 +825,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   How many CRLs to cache in memory in connections to Vault.
   Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
   Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+  If not specified, AcraServer uses value from `--tls_crl_cache_size` flag.
 
 
 * `--vault_tls_crl_client_cache_time=<seconds>`
 
   How long to keep CRLs cached, in seconds for connections to Vault.
   Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+  If not specified, AcraServer uses value from `--tls_crl_cache_time` flag.
 
 
 * `--vault_tls_crl_client_check_only_leaf_certificate={true|false}`
@@ -813,6 +845,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+  If not specified, AcraServer uses value from `--tls_crl_check_only_leaf_certificate` flag.
 
 
 * `--vault_tls_crl_client_from_cert=<policy>`
@@ -825,12 +858,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--vault_tls_crl_client_url` flags.
+  If not specified, AcraServer uses value from `--tls_crl_from_cert` flag.
 
 
 * `--vault_tls_crl_client_url=<url>`
 
   CRL's URL for outcoming TLS connections to Vault.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_crl_url` flag.
 
 
 * `--vault_tls_ocsp_client_check_only_leaf_certificate={true|false}`
@@ -843,6 +878,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know whom to ask about them.
+  If not specified, AcraServer uses value from `--tls_ocsp_check_only_leaf_certificate` flag.
 
 
 * `--vault_tls_ocsp_client_from_cert=<policy>`
@@ -855,6 +891,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--vault_tls_ocsp_client_url` flags.
+  If not specified, AcraServer uses value from `--tls_ocsp_from_cert` flag.
 
 
 * `--vault_tls_ocsp_client_required=<policy>`
@@ -863,14 +900,15 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  If not specified, AcraServer uses value from `--tls_ocsp_required` flag.
 
 
 * `--vault_tls_ocsp_client_url=<url>`
 
   OCSP service URL for outgoing TLS connections to check Vaults' certificates.
   Empty by default.
+  If not specified, AcraServer uses value from `--tls_ocsp_url` flag.
 
 {{< hint info >}}
 **Note**:

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -203,7 +203,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
   If not specified, AcraServer uses value from `--tls_ocsp_from_cert` flag.
 
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/disable.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/disable.md
@@ -121,7 +121,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/disable.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/disable.md
@@ -55,7 +55,7 @@ weight: 2
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -71,7 +71,7 @@ weight: 2
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -121,7 +121,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -159,7 +159,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -168,8 +168,7 @@ weight: 2
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/disable.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/disable.md
@@ -159,7 +159,7 @@ weight: 2
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/enable.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/enable.md
@@ -55,7 +55,7 @@ weight: 3
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -71,7 +71,7 @@ weight: 3
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -121,7 +121,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -159,7 +159,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -168,8 +168,7 @@ weight: 3
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/enable.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/enable.md
@@ -159,7 +159,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/enable.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/enable.md
@@ -121,7 +121,7 @@ weight: 3
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/remove.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/remove.md
@@ -133,7 +133,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/remove.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/remove.md
@@ -171,7 +171,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/remove.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/remove.md
@@ -67,7 +67,7 @@ weight: 4
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -83,7 +83,7 @@ weight: 4
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -133,7 +133,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -171,7 +171,7 @@ weight: 4
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -180,8 +180,7 @@ weight: 4
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/status.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/status.md
@@ -159,7 +159,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
+  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/status.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/status.md
@@ -121,7 +121,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
+  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-tokens/status.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-tokens/status.md
@@ -55,7 +55,7 @@ weight: 1
 
   Set authentication mode that will be used for TLS connection with Redis.
 
-  * `0` — do not request client certificate, ignore it if received;
+  * `-1` — not specified, common `--tls_ca` value will be used.
   * `1` — request client certificate, but don't require it;
   * `2` — expect to receive at least one certificate to continue the handshake;
   * `3` — don't require client certificate, but validate it if client actually sent it;
@@ -71,7 +71,7 @@ weight: 1
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Redis (AcraServer works as "client" when communicating with Redis).
+  Path to TLS certificate presented to Redis.
   Empty by default.
 
 
@@ -121,7 +121,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_crl_*_url` flags. See [Configuring & maintaining > TLS > CRL](/acra/configuring-maintaining/tls/crl/).
 
 
 * `--redis_tls_crl_client_url=<url>`
@@ -159,7 +159,7 @@ weight: 1
   * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
-  "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags, see [Configuring & maintaining > TLS > OCSP](/acra/configuring-maintaining/tls/ocsp/).
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -168,8 +168,7 @@ weight: 1
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 
 * `--redis_tls_ocsp_client_url=<url>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-translator.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-translator.md
@@ -97,21 +97,23 @@ weight: 4
 
 * `--redis_tls_client_ca=<filename>`
 
-  Path to additional CA certificate for Redis' certificate validation (overrides `--tls_ca`).
+  Path to additional CA certificate for Redis' certificate validation.
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_ca` flag.
 
 
 * `--redis_tls_client_cert=<filename>`
 
-  Path to server TLS certificate presented to Redis (overrides `--tls_cert`).
+  Path to TLS certificate presented to Redis.
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_cert` flag.
 
 
 * `--redis_tls_client_key=<filename>`
 
-  Path to private key of the TLS certificate presented to Redis (overrides `--tls_key`).
+  Path to private key of the TLS certificate presented to Redis.
   Empty by default.
-
+  If not specified, AcraTranslator uses value from `--tls_key` flag.
 
 * `--redis_tls_client_sni=<SNI>`
 
@@ -124,12 +126,14 @@ weight: 4
   How many CRLs to cache in memory in connections to Redis.
   Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
   Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+  If not specified, AcraTranslator uses value from `--tls_crl_cache_size` flag.
 
 
 * `--redis_tls_crl_client_cache_time=<seconds>`
 
   How long to keep CRLs cached, in seconds for connections to Redis.
   Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+  If not specified, AcraTranslator uses value from `--tls_crl_cache_time` flag.
 
 
 * `--redis_tls_crl_client_check_only_leaf_certificate={true|false}`
@@ -142,6 +146,7 @@ weight: 4
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+  If not specified, AcraTranslator uses value from `--tls_crl_check_only_leaf_certificate` flag.
 
 
 * `--redis_tls_crl_client_from_cert=<policy>`
@@ -154,12 +159,14 @@ weight: 4
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--redis_tls_crl_client_url` flags.
+  If not specified, AcraTranslator uses value from `--tls_crl_from_cert` flag.
 
 
 * `--redis_tls_crl_client_url=<url>`
 
   CRL's URL for outcoming TLS connections to Redis.
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_crl_url` flag.
 
 
 * `--redis_tls_enable=<true|false>`
@@ -180,6 +187,7 @@ weight: 4
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know whom to ask about them.
+  If not specified, AcraTranslator uses value from `--tls_ocsp_check_only_leaf_certificate` flag.
 
 
 * `--redis_tls_ocsp_client_from_cert=<policy>`
@@ -192,6 +200,7 @@ weight: 4
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--redis_tls_ocsp_client_url` flags.
+  If not specified, AcraTranslator uses value from `--tls_ocsp_from_cert` flag.
 
 
 * `--redis_tls_ocsp_client_required=<policy>`
@@ -200,14 +209,15 @@ weight: 4
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  If not specified, AcraTranslator uses value from `--tls_ocsp_required` flag.
 
 
 * `--redis_tls_ocsp_client_url=<url>`
 
   OCSP service URL for outgoing TLS connections to check Redis' certificates.
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_ocsp_url` flag.
 
 * `--securesession_id=<id>`
 
@@ -433,6 +443,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `4` — (default) request and validate client certificate.
 
   These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
+  If not specified, AcraTranslator uses value from `--tls_auth` flag.
 
 * `--vault_tls_ca_path=<filename>`
 
@@ -442,20 +453,23 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
 * `--vault_tls_client_ca=<filename>`
 
-  Path to AcraServer TLS certificate's CA certificate for Vault certificate validation (AcraServer works as "client" when communicating with Vault).
+  Path to AcraTranslator TLS certificate's CA certificate for Vault certificate validation (AcraTranslator works as "client" when communicating with Vault).
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_ca` flag.
 
 
 * `--vault_tls_client_cert=<filename>`
 
-  Path to AcraServer TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to AcraTranslator TLS certificate presented to Vault (AcraTranslator works as "client" when communicating with Vault).
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_cert` flag.
 
 
 * `--vault_tls_client_key=<filename>`
 
-  Path to AcraServer TLS certificate's private key of the TLS certificate presented to Vault (AcraServer works as "client" when communicating with Vault).
+  Path to AcraTranslator TLS certificate's private key of the TLS certificate presented to Vault (AcraTranslator works as "client" when communicating with Vault).
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_key` flag.
 
 
 * `--vault_tls_client_sni=<SNI>`
@@ -469,12 +483,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   How many CRLs to cache in memory in connections to Vault.
   Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
   Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+  If not specified, AcraTranslator uses value from `--tls_crl_cache_size` flag.
 
 
 * `--vault_tls_crl_client_cache_time=<seconds>`
 
   How long to keep CRLs cached, in seconds for connections to Vault.
   Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+  If not specified, AcraTranslator uses value from `--tls_cache_time` flag.
 
 
 * `--vault_tls_crl_client_check_only_leaf_certificate={true|false}`
@@ -487,6 +503,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+  If not specified, AcraTranslator uses value from `--tls_crl_check_only_leaf_certificate` flag.
 
 
 * `--vault_tls_crl_client_from_cert=<policy>`
@@ -499,12 +516,14 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `ignore` — completely ignore CRL's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--vault_tls_crl_client_url` flags.
+  If not specified, AcraTranslator uses value from `--tls_crl_from_cert` flag.
 
 
 * `--vault_tls_crl_client_url=<url>`
 
   CRL's URL for outcoming TLS connections to Vault.
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_crl_url` flag.
 
 
 * `--vault_tls_ocsp_client_check_only_leaf_certificate={true|false}`
@@ -517,6 +536,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know whom to ask about them.
+  If not specified, AcraTranslator uses value from `--tls_ocsp_check_only_leaf_certificate` flag.
 
 
 * `--vault_tls_ocsp_client_from_cert=<policy>`
@@ -529,6 +549,7 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
   * `ignore` — completely ignore OCSP's URL(s) specified in certificate
 
   "URL from configuration" above means the one configured with `--vault_tls_ocsp_client_url` flags.
+  If not specified, AcraTranslator uses value from `--tls_ocsp_from_cert` flag.
 
 
 * `--vault_tls_ocsp_client_required=<policy>`
@@ -537,14 +558,15 @@ Should be provided only with `--keystore_encryption_type=<kms_encrypted_master_k
 
   * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
-  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
-    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+  If not specified, AcraTranslator uses value from `--tls_ocsp_required` flag.
 
 
 * `--vault_tls_ocsp_client_url=<url>`
 
   OCSP service URL for outgoing TLS connections to check Vaults' certificates.
   Empty by default.
+  If not specified, AcraTranslator uses value from `--tls_ocsp_url` flag.
 
 {{< hint info >}}
 **Note**:

--- a/content/acra/configuring-maintaining/tls/crl.md
+++ b/content/acra/configuring-maintaining/tls/crl.md
@@ -30,13 +30,11 @@ CRL-related flags and their descriptions. Works for `acra-connector`, `acra-serv
 
 * `--tls_crl_client_url=<url>`
 
-  CRL's URL for incoming TLS connections to check client certificates.
-  Empty by default. Supported on AcraServer only.
+  Works as `--tls_crl_url` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_url` flag. **Supported on AcraServer only.**
 
 * `--tls_crl_database_url=<url>`
 
-  CRL's URL for outgoing TLS connections to check database certificates.
-  Empty by default. Supported on AcraServer only.
+  Works as `--tls_crl_url` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_url` flag. **Supported on AcraServer only.**
 
 * `--tls_crl_from_cert=<policy>`
 
@@ -49,6 +47,14 @@ CRL-related flags and their descriptions. Works for `acra-connector`, `acra-serv
 
   "URL from configuration" above means the one configured with `--tls_crl_*_url` flags.
 
+* `--tls_crl_client_from_cert=<policy>`
+
+  Works as `--tls_crl_from_cert` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_from_cert` flag. **Supported on AcraServer only.**
+
+* `--tls_crl_database_from_cert=<policy>`
+
+  Works as `--tls_crl_from_cert` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_from_cert` flag. **Supported on AcraServer only.**
+
 * `--tls_crl_check_only_leaf_certificate={true|false}`
 
   This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
@@ -60,16 +66,40 @@ CRL-related flags and their descriptions. Works for `acra-connector`, `acra-serv
   Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
 
+* `--tls_crl_client_check_only_leaf_certificate=<policy>`
+
+  Works as `--tls_crl_check_only_leaf_certificate` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_check_only_leaf_certificate` flag. **Supported on AcraServer only.**
+
+* `--tls_crl_database_check_only_leaf_certificate=<policy>`
+
+  Works as `--tls_crl_check_only_leaf_certificate` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_check_only_leaf_certificate` flag. **Supported on AcraServer only.**
+
 * `--tls_crl_cache_size=<count>`
 
   How many CRLs to cache in memory.
   Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
   Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
 
+* `--tls_crl_client_cache_size=<policy>`
+
+  Works as `--tls_crl_cache_size` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_cache_size` flag. **Supported on AcraServer only.**
+
+* `--tls_crl_database_cache_size=<policy>`
+
+  Works as `--tls_crl_cache_size` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_cache_size` flag. **Supported on AcraServer only.**
+
 * `--tls_crl_cache_time=<seconds>`
 
   How long to keep CRLs cached, in seconds.
   Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+
+* `--tls_crl_client_cache_time=<policy>`
+
+  Works as `--tls_crl_cache_time` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_cache_time` flag. **Supported on AcraServer only.**
+
+* `--tls_crl_database_cache_time=<policy>`
+
+  Works as `--tls_crl_cache_time` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_crl_cache_time` flag. **Supported on AcraServer only.**
 
 ## Including CRL's URL while signing CSR
 

--- a/content/acra/configuring-maintaining/tls/ocsp.md
+++ b/content/acra/configuring-maintaining/tls/ocsp.md
@@ -24,13 +24,11 @@ OCSP-related flags and their description. Works for `acra-connector`, `acra-serv
 
 * `--tls_ocsp_client_url=<url>`
 
-  OCSP service URL for incoming TLS connections to check client certificates.
-  Empty by default. Supported on AcraServer only.
+  Works as `--tls_ocsp_url` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_url` flag. **Supported on AcraServer only.**
 
 * `--tls_ocsp_database_url=<url>`
 
-  OCSP service URL for outgoing TLS connections to check database certificates.
-  Empty by default. Supported on AcraServer only.
+  Works as `--tls_ocsp_url` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_url` flag. **Supported on AcraServer only.**
 
 * `--tls_ocsp_required=<policy>`
 
@@ -40,6 +38,14 @@ OCSP-related flags and their description. Works for `acra-connector`, `acra-serv
   * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
   * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
     continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+
+* `--tls_ocsp_client_required=<policy>`
+
+  Works as `--tls_ocsp_required` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_required` flag. **Supported on AcraServer only.**
+
+* `--tls_ocsp_database_required=<policy>`
+
+  Works as `--tls_ocsp_required` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_required` flag. **Supported on AcraServer only.**
 
 * `--tls_ocsp_from_cert=<policy>`
 
@@ -52,6 +58,14 @@ OCSP-related flags and their description. Works for `acra-connector`, `acra-serv
 
   "URL from configuration" above means the one configured with `--tls_ocsp_*_url` flags.
 
+* `--tls_ocsp_client_from_cert=<policy>`
+
+  Works as `--tls_ocsp_from_cert` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_from_cert` flag. **Supported on AcraServer only.**
+
+* `--tls_ocsp_database_from_cert=<policy>`
+
+  Works as `--tls_ocsp_from_cert` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_from_cert` flag. **Supported on AcraServer only.**
+
 * `--tls_ocsp_check_only_leaf_certificate={true|false}`
 
   This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
@@ -62,6 +76,14 @@ OCSP-related flags and their description. Works for `acra-connector`, `acra-serv
   This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
   Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
   these intermediate CAs won't be validated since we don't know whom to ask about them.
+
+* `--tls_ocsp_client_check_only_leaf_certificate={true|false}`
+
+  Works as `--tls_ocsp_check_only_leaf_certificate` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_check_only_leaf_certificate` flag. **Supported on AcraServer only.**
+
+* `--tls_ocsp_database_check_only_leaf_certificate={true|false}`
+
+  Works as `--tls_ocsp_check_only_leaf_certificate` flag but applied only for connections between application and AcraServer. If not specified, AcraServer uses value from `--tls_ocsp_check_only_leaf_certificate` flag. **Supported on AcraServer only.**
 
 ## Including OCSP's URL while signing CSR
 


### PR DESCRIPTION
**UPD.** It's cherry-picked actual changes from #290 without rows `If not specified, XXX uses value from ...` because common flags available only for AcraServer and AcraTranslator

* added missing flags on ocsp/crl pages
* unified descriptions of same flags for pages of all services which use them in same manner
* updated descriptions with note that side-specific (client/database) flags use common flag values if not specified
* changed incorrect previously copy-pasted service names (AcraServer) to the proper service's name (AcraServer -> acra-backup on acra-backup's page)

These changes related to https://github.com/cossacklabs/acra/pull/617 and https://github.com/cossacklabs/acra/issues/615