### PR TITLE
Actualize stable with docs update

### DIFF
--- a/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-keys/destroy.md
@@ -5,10 +5,11 @@ weight: 7
 
 # destroy
 
-**`destroy`** is `acra-keys` subcommand used for destroying keypair from the keystore.
+**`destroy`** is `acra-keys` subcommand used for destroying keys from the keystore `v1` or `v2`.
 
 {{< hint warning >}}
-Since 0.91.0 `acra-keys` **`destroy`** doesn't support destroying keys and will be extended in subsequent versions.
+Before 0.91.0 `acra-keys` **`destroy`** was used to destroy only transport keys. Since 0.91.0 transport keys support is deprecated, `acra-keys` **`destroy`** is unused.
+Starting from 0.95.0 `acra-keys` **`destroy`** is extended to delete any types of keys.
 {{< /hint >}}
 
 ## Command line flags
@@ -359,7 +360,7 @@ Should be provided only with `--keystore_encryption_type=<vault_master_key>` fla
 
 ## Usage example
 
-For example, lets generate several transport keys using [`generate`]({{< ref "/acra/configuring-maintaining/general-configuration/acra-keys/generate" >}}) subcommand:
+For example, lets generate hmac symmetric key used for searchable encryption using [`generate`]({{< ref "/acra/configuring-maintaining/general-configuration/acra-keys/generate" >}}) subcommand:
 
 {{< hint info >}}
 **Note:**
@@ -367,29 +368,31 @@ Make sure you have set `ACRA_MASTER_KEY` env variable for keystore `v1`.
 {{< /hint >}}
 
 ```
-$ acra-keys generate --client_id=user1 --keystore=v1 --acraconnector_transport_key --acraserver_transport_key
+$ acra-keys generate --client_id=user1 --keystore=v1 --search_hmac_symmetric_key
 
-INFO[0000] Initializing ACRA_MASTER_KEY loader...       
-INFO[0000] Initialized default env ACRA_MASTER_KEY loader 
-INFO[0000] Generated AcraConnector transport key        
-INFO[0000] Generated AcraServer transport key
+INFO[0000] Initializing default env ACRA_MASTER_KEY loader 
+INFO[0000] Generated HMAC key for searchable encryption
 ```
 
 To destroy the keypair use the following command:
 ```
-$ acra-keys destroy client/user1/transport/connector
+$ acra-keys destroy client/user1/searchable
 
-INFO[0000] Initializing ACRA_MASTER_KEY loader...       
-INFO[0000] Initialized default env ACRA_MASTER_KEY loader
+INFO[0000] Initializing default env ACRA_MASTER_KEY loader 
 ```
 
 {{< hint info >}}
 **Note:**
-Currently, only some key kinds are supported for destroying via `destroy` subcommand.
 Here is the list of supported key kinds:
 
 <!-- cmd/acra-keys/keys/command-line.go func ParseKeyKind -->
-- `client/<client ID>/transport/connector`
-- `client/<client ID>/transport/server`
-- `client/<client ID>/transport/translator`
+- `client/<client ID>/searchable`
+- `client/<client ID>/storage`
+- `client/<client ID>/symmetric`
+- `poison-record`
+- `poison-record-symmetric`
+
+- `client/<client ID>/transport/connector` - (deprecated) used until version 0.91.0
+- `client/<client ID>/transport/server` - (deprecated) used until version 0.91.0
+- `client/<client ID>/transport/translator` - (deprecated) used until version 0.91.0
 {{< /hint >}}

--- a/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rollback.md
@@ -77,6 +77,212 @@ Zones are deprecated since 0.94.0, will be removed in 0.95.0.
   File for store inserts queries. 
   Default is `decrypted.sql`.
 
+#### TLS
+
+* `--tls_database_enabled=<true|false>`
+
+  Turns on/off TLS for connection with Database to `--db_connection_string`.
+
+  * `true` — turns on
+  * `false` — (default) turns off.
+
+* `--tls_auth=<mode>`
+
+  Set authentication mode that will be used for TLS connection.
+
+  * `0` — do not request client certificate, ignore it if received;
+  * `1` — request client certificate, but don't require it;
+  * `2` — expect to receive at least one certificate to continue the handshake;
+  * `3` — don't require client certificate, but validate it if client actually sent it;
+  * `4` — (default) request and validate client certificate.
+
+  These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
+
+* `--tls_key=<filename>`
+
+  Path to acra-rollback TLS certificate's private key of the TLS certificate presented to Database (acra-rollback works as "client" when communicating with Database).
+  Empty by default.
+
+* `--tls_cert=<filename>`
+
+  Path to acra-rollback TLS certificate presented to Database (acra-rollback works as "client" when communicating with Database).
+  Empty by default.
+
+* `--tls_ca=<filename>`
+
+  Path to acra-rollback TLS certificate's CA certificate for Database certificate validation (acra-rollback works as "client" when communicating with Database).
+  Empty by default.
+
+* `--tls_crl_url=<url>`
+
+  URL of the Certificate Revocation List (CRL) to use.
+  Empty by default.
+
+  Can be either `http://` or `file://` (for local files).
+  When using local file, Acra will simply read the file and won't monitor filesystem for changes afterwards.
+  Usual caching rules apply (see `--tls_crl_cache_time`).
+
+* `--tls_crl_from_cert=<policy>`
+
+  How to treat CRL's URL described in a certificate itself
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore CRL's URL(s) specified in certificate
+
+* `--tls_crl_cache_size=<count>`
+
+  How many CRLs to cache in memory.
+  Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
+  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+
+* `--tls_crl_cache_time=<seconds>`
+
+  How long to keep CRLs cached, in seconds.
+  Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+
+* `--tls_crl_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+
+* `--tls_ocsp_required=<policy>`
+
+  How to handle situation when OCSP server doesn't know about requested certificate and returns "Unknown".
+
+  * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
+  * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and
+    continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+
+* `--tls_ocsp_url=<url>`
+
+  URL of OCSP service.
+  Empty by default.
+
+  Should point to HTTP server that accepts `application/ocsp-request` MIME type
+  and responds with `application/ocsp-response`.
+
+* `--tls_ocsp_from_cert=<policy>`
+
+  How to treat OCSP server URL described in a certificate itself.
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore OCSP's URL(s) specified in certificate
+
+* `--tls_ocsp_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know whom to ask about them.
+
+* `--tls_database_auth=<mode>`
+
+  Set authentication mode that will be used for TLS connection with a database.
+  Possible values are the same as for `--tls_auth`.
+  Overrides the `--tls_auth` setting.
+  Default is `-1` which means "take value of `--tls_auth`".
+
+* `--tls_database_key=<filename>`
+
+  Path to acra-rollback TLS certificate's private key of the TLS certificate presented to Database (acra-rollback works as "client" when communicating with Database).
+  Empty by default.
+  If not specified, acra-rollback uses value from `--tls_key` flag.
+
+* `--tls_database_cert=<filename>`
+
+  Path to acra-rollback TLS certificate presented to Database (acra-rollback works as "client" when communicating with Database).
+  Empty by default.
+  If not specified, acra-rollback uses value from `--tls_cert` flag.
+
+* `--tls_database_ca=<filename>`
+
+  Path to acra-rollback TLS certificate's CA certificate for Database certificate validation (acra-rollback works as "client" when communicating with Database).
+  Empty by default.
+  If not specified, acra-rollback uses value from `--tls_ca` flag.
+
+* `--tls_crl_database_from_cert=<policy>`
+
+  How to treat CRL's URL described in a certificate itself (overrides `--tls_crl_from_cert`).
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore CRL's URL(s) specified in certificate
+
+* `--tls_crl_database_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+
+* `--tls_crl_database_cache_size=<count>`
+
+  How many CRLs to cache in memory (overrides `--tls_crl_cache_size`).
+  Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
+  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+
+* `--tls_crl_database_cache_time=<seconds>`
+
+  How long to keep CRLs cached, in seconds (overrides `--tls_crl_cache_time`).
+  Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+
+* `--tls_database_sni=<SNI>`
+
+  Expected Server Name (SNI) of a database.
+  Empty by default which means "don't check the SNI sent by a database".
+
+* `--tls_ocsp_database_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate (overrides `--tls_ocsp_check_only_leaf_certificate`).
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+* `--tls_ocsp_database_url=<url>`
+
+  URL of OCSP service.
+  Empty by default.
+
+  Should point to HTTP server that accepts `application/ocsp-request` MIME type
+  and responds with `application/ocsp-response`.
+
+* `--tls_ocsp_database_from_cert=<policy>`
+
+  How to treat OCSP server URL described in a certificate itself (overrides `--tls_ocsp_database_from_cert`).
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore OCSP's URL(s) specified in certificate
+
+* `--tls_ocsp_database_required=<policy>`
+
+  How to handle situation when OCSP server doesn't know about requested certificate and returns "Unknown" (overrides `--tls_ocsp_required`).
+
+  * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
+  * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+
 #### Redis
 
 * `--redis_db_keys=<number>`

--- a/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-rotate.md
@@ -9,7 +9,6 @@ weight: 8
 
 ## Command line flags
 
-
 ### General flags
 
 * `--mysql_enable={true|false}`
@@ -78,6 +77,211 @@ weight: 8
 * `--file_map_config=<path>`
 
   Path to file with a map of **ZoneId**: **FilePaths** in json format `{"zone_id1": ["filepath1", "filepath2"], "zone_id2": ["filepath1", "filepath2"]}`.
+
+#### TLS
+
+* `--tls_database_enabled=<true|false>`
+
+  Turns on/off TLS for connection with Database to `--db_connection_string`.
+
+  * `true` — turns on
+  * `false` — (default) turns off.
+
+* `--tls_auth=<mode>`
+
+  Set authentication mode that will be used for TLS connection.
+
+  * `0` — do not request client certificate, ignore it if received;
+  * `1` — request client certificate, but don't require it;
+  * `2` — expect to receive at least one certificate to continue the handshake;
+  * `3` — don't require client certificate, but validate it if client actually sent it;
+  * `4` — (default) request and validate client certificate.
+
+  These values correspond to [crypto.tls.ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType).
+
+* `--tls_key=<filename>`
+
+  Path to acra-rotate TLS certificate's private key of the TLS certificate presented to Database (acra-rotate works as "client" when communicating with Database).
+  Empty by default.
+
+* `--tls_cert=<filename>`
+
+  Path to acra-rotate TLS certificate presented to Database (acra-rotate works as "client" when communicating with Database).
+  Empty by default.
+
+* `--tls_ca=<filename>`
+
+  Path to acra-rotate TLS certificate's CA certificate for Database certificate validation (acra-rotate works as "client" when communicating with Database).
+  Empty by default.
+
+* `--tls_crl_url=<url>`
+
+  URL of the Certificate Revocation List (CRL) to use.
+  Empty by default.
+
+  Can be either `http://` or `file://` (for local files).
+  When using local file, Acra will simply read the file and won't monitor filesystem for changes afterwards.
+  Usual caching rules apply (see `--tls_crl_cache_time`).
+
+* `--tls_crl_from_cert=<policy>`
+
+  How to treat CRL's URL described in a certificate itself
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore CRL's URL(s) specified in certificate
+
+* `--tls_crl_cache_size=<count>`
+
+  How many CRLs to cache in memory.
+  Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
+  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+
+* `--tls_crl_cache_time=<seconds>`
+
+  How long to keep CRLs cached, in seconds.
+  Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+
+* `--tls_crl_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+
+* `--tls_ocsp_required=<policy>`
+
+  How to handle situation when OCSP server doesn't know about requested certificate and returns "Unknown".
+
+  * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
+  * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
+
+* `--tls_ocsp_url=<url>`
+
+  URL of OCSP service.
+  Empty by default.
+
+  Should point to HTTP server that accepts `application/ocsp-request` MIME type
+  and responds with `application/ocsp-response`.
+
+* `--tls_ocsp_from_cert=<policy>`
+
+  How to treat OCSP server URL described in a certificate itself.
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore OCSP's URL(s) specified in certificate
+
+* `--tls_ocsp_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there is no OCSP's URL configured and there is no OCSP's URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know whom to ask about them.
+
+* `--tls_database_auth=<mode>`
+
+  Set authentication mode that will be used for TLS connection with a database.
+  Possible values are the same as for `--tls_auth`.
+  Overrides the `--tls_auth` setting.
+  Default is `-1` which means "take value of `--tls_auth`".
+
+* `--tls_database_key=<filename>`
+
+  Path to acra-rotate TLS certificate's private key of the TLS certificate presented to Database (acra-rotate works as "client" when communicating with Database).
+  Empty by default.
+  If not specified, acra-rotate uses value from `--tls_key` flag.
+
+* `--tls_database_cert=<filename>`
+
+  Path to acra-rotate TLS certificate presented to Database (acra-rotate works as "client" when communicating with Database).
+  Empty by default.
+  If not specified, acra-rotate uses value from `--tls_cert` flag.
+
+* `--tls_database_ca=<filename>`
+
+  Path to acra-rotate TLS certificate's CA certificate for Database certificate validation (acra-rotate works as "client" when communicating with Database).
+  Empty by default.
+  If not specified, acra-rotate uses value from `--tls_ca` flag.
+
+* `--tls_crl_database_from_cert=<policy>`
+
+  How to treat CRL's URL described in a certificate itself (overrides `--tls_crl_from_cert`).
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try first URL from certificate, if it does not contain checked certificate, stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore CRL's URL(s) specified in certificate
+
+* `--tls_crl_database_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate.
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+  This option may be enabled in cases when intermediate CAs are trusted and there is no need to verify them all the time.
+  Also, even if this flag is `false` but there is no CRL's URL configured and there is no CRL's URL in intermediate CA certificates,
+  these intermediate CAs won't be validated since we don't know which CRLs could be used for validation.
+
+* `--tls_crl_database_cache_size=<count>`
+
+  How many CRLs to cache in memory (overrides `--tls_crl_cache_size`).
+  Use `0` to disable caching. Maximum is `1000000`. Default is `16`.
+  Cache uses [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) policy.
+
+* `--tls_crl_database_cache_time=<seconds>`
+
+  How long to keep CRLs cached, in seconds (overrides `--tls_crl_cache_time`).
+  Use `0` to disable caching. Maximum is `300` seconds. Default is `0`.
+
+* `--tls_database_sni=<SNI>`
+
+  Expected Server Name (SNI) of a database.
+  Empty by default which means "don't check the SNI sent by a database".
+
+* `--tls_ocsp_database_check_only_leaf_certificate={true|false}`
+
+  This flag controls behavior of validator in cases when certificate chain contains at least one intermediate certificate (overrides `--tls_ocsp_check_only_leaf_certificate`).
+
+  * `true` — validate only leaf certificate
+  * `false` — (default) validate leaf certificate and all intermediate certificates
+
+* `--tls_ocsp_database_url=<url>`
+
+  URL of OCSP service.
+  Empty by default.
+
+  Should point to HTTP server that accepts `application/ocsp-request` MIME type
+  and responds with `application/ocsp-response`.
+
+* `--tls_ocsp_database_from_cert=<policy>`
+
+  How to treat OCSP server URL described in a certificate itself (overrides `--tls_ocsp_database_from_cert`).
+
+  * `use` — try URL(s) from certificate after the one from configuration (if set)
+  * `trust` — try URL(s) from certificate, if server returns "Valid", stop further checks
+  * `prefer` — (default) try URL(s) from certificate before the one from configuration (if set)
+  * `ignore` — completely ignore OCSP's URL(s) specified in certificate
+
+* `--tls_ocsp_database_required=<policy>`
+
+  How to handle situation when OCSP server doesn't know about requested certificate and returns "Unknown" (overrides `--tls_ocsp_required`).
+
+  * `denyUnknown` — (default) consider "Unknown" response an error, certificate will be rejected
+  * `allowUnknown` — reverse of `denyUnknown`, allow certificates unknown to OCSP server
+  * `requireGood` — require all known OCSP servers to respond "Good" in order to allow certificate and continue TLS handshake, this includes all URLs validator can use, from certificate (if not ignored) and from configuration
 
 #### Redis
 

--- a/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
+++ b/content/acra/configuring-maintaining/general-configuration/acra-server/_index.md
@@ -416,6 +416,8 @@ weight: 3
   {{< hint warning >}}
   **Note:**
   The default configuration with `--http_api_tls_transport_enable=false` is **insecure**. Enable TLS whenever possible.
+  
+  Starting from `0.96.0` the `--http_api_tls_transport_enable` value will be `true` by default.
   {{< /hint >}}
 
 * `--incoming_connection_api_port=<port>`


### PR DESCRIPTION
- Actualize info about acra-keys destroy subcommand
- Added info about recently added TLS flags in acra-rotate/acra-rollback tools
- Added info about http_api_tls_transport_enable flag default value