### PR TITLE
Update supported golang versions

### DIFF
--- a/content/acra/getting-started/requirements/_index.md
+++ b/content/acra/getting-started/requirements/_index.md
@@ -18,7 +18,7 @@ Currently, all [the images we provide](/acra/getting-started/installing/launchin
 ### Build from sources
 
 The requirements are not so strict:
-* Golang compiler (we support the latest 3 minor versions) should be able to build binaries for your OS/CPU (though Windows is not supported)
+* Golang compiler (we support and test the only latest stable version) should be able to build binaries for your OS/CPU (though Windows is not supported)
 * [Themis](https://github.com/cossacklabs/themis/#availability) crypto libraries should be installed on target system
 
 ### TLS


### PR DESCRIPTION
Added note that we support only latest version of the golang compiler according to last decisions and changes