### PR TITLE
jsthemis: Describe issues with Nodejs and Openssl

### DIFF
--- a/content/themis/languages/nodejs/_index.md
+++ b/content/themis/languages/nodejs/_index.md
@@ -25,8 +25,7 @@ bookCollapseSection: true
 
 ## Supported Node.js versions
 
-JsThemis is tested and supported on the current LTS versions of Node.js
-(v8, v10, v12).
+JsThemis is tested and supported on the current LTS versions of Node.js: v12, v16 and some of the 18.x versions.
 
 ## Getting started
 

--- a/content/themis/languages/nodejs/_index.md
+++ b/content/themis/languages/nodejs/_index.md
@@ -25,7 +25,7 @@ bookCollapseSection: true
 
 ## Supported Node.js versions
 
-JsThemis is tested and supported on the current LTS versions of Node.js: v12, v16 and some of the 18.x versions.
+JsThemis is tested and supported on the current LTS versions of Node.js: v12, v14, v16 and some of the 18.x versions.
 
 ## Getting started
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -117,7 +117,7 @@ $ node -e "console.log(process.versions['openssl'])"
 3.0.2+quic
 ```
 
-If the semantic versions are the same, you are good to go! If they differ, however, there are a few ways to resolve the situation, but there is no easy answer:
+If the semantic versions are the same, you are good to go! If they differ, however, there are a few ways to resolve the situation, but there is no easy answer. For instance, here is what we use while testing Themis in CI:
 
 1. Choose the Node.js version with the OpenSSL that matches with your systems' one or that has no OpenSSL built in (there may be versions of Node.js that use shared OpenSSL).
 
@@ -125,8 +125,10 @@ If the semantic versions are the same, you are good to go! If they differ, howev
 
 2. Try another distribution with OpenSSL that matches Node.js.
 
-3. Try to install OpenSSL version that matches your Node.js. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
+Furthermore, here is how community solves this issue:
 
-4. You can try to build Themis and JsThemis from the sources with [Boringssl engine](../../../installation/installation-from-sources/#boringssl).
+1. Try to install OpenSSL version that matches your Node.js. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
+
+2. You can try to build Themis and JsThemis from the sources with [Boringssl engine](../../../installation/installation-from-sources/#boringssl).
 
 However, none of these options are ideal because they can lock you to specific versions of software and disable the ability to update components and dependencies.

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -96,7 +96,7 @@ you can manually build and install the latest version of Themis from source code
 
 ## Matching OpenSSL versions
 
-JsThemis is a simple addon to Nodejs that provides bindings to the Themis library, which is itself installed as a shared library in the system. In turn, Themis depends on OpenSSL installed in the system.
+JsThemis is a simple library to Node.js that provides bindings to the Themis Core library, which is itself installed as a shared library in the system. In turn, Themis Core depends on OpenSSL installed in the system.
 
 However, [Nodejs often comes with its own OpenSSL version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some OpenSSL functions will be linked directly from Nodejs and the others will come from the system's OpenSSL. If these OpenSSL versions are not the same, JsThemis will not work correctly or crash.
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -14,7 +14,7 @@ Usually you want to install the stable package to benefit from automatic depende
 However, you can also build and install the latest JsThemis from the source code.
 
   {{< hint warning >}}
-  **Note**: Due to some issues with Openssl statically linked into Nodejs, for correct JsThemis operation, you need to ensure that the Nodejs and system Openssl versions match. Otherwise, you may encounter failures or crashes at runtime. Refer to [Matching Openssl versions](#matching-openssl-versions) for more details.
+  **Note**: Due to some issues with OpenSSL statically linked into Nodejs, for correct JsThemis operation, you need to ensure that the Nodejs and system OpenSSL versions match. Otherwise, you may encounter failures or crashes at runtime. Refer to [Matching OpenSSL versions](#matching-openssl-versions) for more details.
   {{< /hint >}}
 
 ## Installing stable version on Linux
@@ -94,11 +94,11 @@ you can manually build and install the latest version of Themis from source code
     npm install /path/to/jsthemis.tgz
     ```
 
-## Matching Openssl versions
+## Matching OpenSSL versions
 
-JsThemis is a simple addon to Nodejs that provides bindings to the Themis library, which is itself installed as a shared library in the system. In turn, Themis depends on Openssl installed in the system.
+JsThemis is a simple addon to Nodejs that provides bindings to the Themis library, which is itself installed as a shared library in the system. In turn, Themis depends on OpenSSL installed in the system.
 
-However, [Nodejs often comes with its own Openssl version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some Openssl functions will be linked directly from Nodejs and the others will come from the system's Openssl. If these Openssl versions are not the same, JsThemis will not work correctly or crash.
+However, [Nodejs often comes with its own OpenSSL version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some OpenSSL functions will be linked directly from Nodejs and the others will come from the system's OpenSSL. If these OpenSSL versions are not the same, JsThemis will not work correctly or crash.
 
 ```
                           +-----> Node openssl
@@ -108,7 +108,7 @@ jsthemis ----> libthemis -+
                           +-----> System openssl
 ```
 
-For these reasons, before installing JsThemis, it is critical to ensure that the Nodejs and system Openssl versions are the same. To do so, you can check the output of these commands:
+For these reasons, before installing JsThemis, it is critical to ensure that the Nodejs and system OpenSSL versions are the same. To do so, you can check the output of these commands:
 
 ```bash
 $ openssl version
@@ -119,13 +119,13 @@ $ node -e "console.log(process.versions['openssl'])"
 
 If the semantic versions are the same, you are good to go! If they differ, however, there are a few ways to resolve the situation, but there is no easy answer:
 
-1. Choose the Nodejs version with the Openssl that matches with your systems' one or that has no Openssl built in (there may be versions of Nodejs that use shared Openssl).
+1. Choose the Nodejs version with the OpenSSL that matches with your systems' one or that has no OpenSSL built in (there may be versions of Nodejs that use shared OpenSSL).
 
-   For example, Ubuntu Jammy Jellyfish (22.04) has Openssl 3.0.2, so the only Nodejs versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has Openssl 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that Openssl 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
+   For example, Ubuntu Jammy Jellyfish (22.04) has OpenSSL 3.0.2, so the only Nodejs versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has OpenSSL 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that OpenSSL 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
 
-2. Try another distribution with Openssl that matches Nodejs.
+2. Try another distribution with OpenSSL that matches Nodejs.
 
-3. Try to install Openssl version that matches your Nodejs. Probably, it will require building Openssl from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new Openssl.
+3. Try to install OpenSSL version that matches your Nodejs. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
 
 4. You can try to build Themis and JsThemis from the sources with [Boringssl engine](../../../installation/installation-from-sources/#boringssl).
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -98,7 +98,7 @@ you can manually build and install the latest version of Themis from source code
 
 JsThemis is a simple library to Node.js that provides bindings to the Themis Core library, which is itself installed as a shared library in the system. In turn, Themis Core depends on OpenSSL installed in the system.
 
-However, [Nodejs often comes with its own OpenSSL version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some OpenSSL functions will be linked directly from Nodejs and the others will come from the system's OpenSSL. If these OpenSSL versions are not the same, JsThemis will not work correctly or crash.
+However, [Nodejs often comes with its own OpenSSL version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some OpenSSL functions will be linked directly from Nodejs and the others will come from the system's OpenSSL. If these OpenSSL versions are not the same, JsThemis could become confused and crash.
 
 ```
                           +-----> Node openssl

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -14,7 +14,7 @@ Usually you want to install the stable package to benefit from automatic depende
 However, you can also build and install the latest JsThemis from the source code.
 
   {{< hint warning >}}
-  **Note**: Due to some issues with OpenSSL statically linked into Nodejs, for correct JsThemis operation, you need to ensure that the Nodejs and system OpenSSL versions match. Otherwise, you may encounter failures or crashes at runtime. Refer to [Matching OpenSSL versions](#matching-openssl-versions) for more details.
+  **Note**: Due to some issues with OpenSSL statically linked into Node.js, for correct JsThemis operation, you need to ensure that the Node.js and system OpenSSL versions match. Otherwise, you may encounter failures or crashes at runtime. Refer to [Matching OpenSSL versions](#matching-openssl-versions) for more details.
   {{< /hint >}}
 
 ## Installing stable version on Linux
@@ -98,7 +98,7 @@ you can manually build and install the latest version of Themis from source code
 
 JsThemis is a simple library to Node.js that provides bindings to the Themis Core library, which is itself installed as a shared library in the system. In turn, Themis Core depends on OpenSSL installed in the system.
 
-However, [Nodejs often comes with its own OpenSSL version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some OpenSSL functions will be linked directly from Nodejs and the others will come from the system's OpenSSL. If these OpenSSL versions are not the same, JsThemis could become confused and crash.
+However, [Node.js often comes with its own OpenSSL version](https://github.com/nodejs/TSC/blob/main/OpenSSL-Strategy.md) included in the binary. This is a problem for JsThemis, because due to how linkage works, some OpenSSL functions will be linked directly from Node.js and the others will come from the system's OpenSSL. If these OpenSSL versions are not the same, JsThemis could become confused and crash.
 
 ```
                           +-----> Node openssl
@@ -121,7 +121,7 @@ If the semantic versions are the same, you are good to go! If they differ, howev
 
 1. Choose the Node.js version with the OpenSSL that matches with your systems' one or that has no OpenSSL built in (there may be versions of Node.js that use shared OpenSSL).
 
-   For example, Ubuntu Jammy Jellyfish (22.04) has OpenSSL 3.0.2, so the only Nodejs versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has OpenSSL 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that OpenSSL 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
+   For example, Ubuntu Jammy Jellyfish (22.04) has OpenSSL 3.0.2, so the only Node.js versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has OpenSSL 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that OpenSSL 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
 
 2. Try another distribution with OpenSSL that matches Node.js.
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -108,7 +108,7 @@ jsthemis ----> libthemis -+
                           +-----> System openssl
 ```
 
-For these reasons, before installing JsThemis, it is critical to ensure that the Nodejs and system OpenSSL versions are the same. To do so, you can check the output of these commands:
+For these reasons, before installing JsThemis, it is critical to ensure that the Node.js and system OpenSSL versions are the same. To do so, you can check the output of these commands:
 
 ```bash
 $ openssl version

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -123,7 +123,7 @@ If the semantic versions are the same, you are good to go! If they differ, howev
 
    For example, Ubuntu Jammy Jellyfish (22.04) has OpenSSL 3.0.2, so the only Nodejs versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has OpenSSL 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that OpenSSL 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
 
-2. Try another distribution with OpenSSL that matches Nodejs.
+2. Try another distribution with OpenSSL that matches Node.js.
 
 3. Try to install OpenSSL version that matches your Nodejs. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -119,7 +119,7 @@ $ node -e "console.log(process.versions['openssl'])"
 
 If the semantic versions are the same, you are good to go! If they differ, however, there are a few ways to resolve the situation, but there is no easy answer:
 
-1. Choose the Nodejs version with the OpenSSL that matches with your systems' one or that has no OpenSSL built in (there may be versions of Nodejs that use shared OpenSSL).
+1. Choose the Node.js version with the OpenSSL that matches with your systems' one or that has no OpenSSL built in (there may be versions of Node.js that use shared OpenSSL).
 
    For example, Ubuntu Jammy Jellyfish (22.04) has OpenSSL 3.0.2, so the only Nodejs versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has OpenSSL 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that OpenSSL 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -125,7 +125,7 @@ If the semantic versions are the same, you are good to go! If they differ, howev
 
 2. Try another distribution with OpenSSL that matches Node.js.
 
-3. Try to install OpenSSL version that matches your Nodejs. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
+3. Try to install OpenSSL version that matches your Node.js. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
 
 4. You can try to build Themis and JsThemis from the sources with [Boringssl engine](../../../installation/installation-from-sources/#boringssl).
 

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -129,6 +129,6 @@ Furthermore, here is how community solves this issue:
 
 1. Try to install OpenSSL version that matches your Node.js. Probably, it will require building OpenSSL from the sources. Then, you will have to rebuild [Themis and JsThemis from sources](#building-latest-version-from-source). Don't forget to [specify the path](../../../installation/installation-from-sources/#cryptographic-backends) to the new OpenSSL.
 
-2. You can try to build Themis and JsThemis from the sources with [Boringssl engine](../../../installation/installation-from-sources/#boringssl).
+2. You can try to build and install Themis Core and JsThemis from the sources with [Boringssl engine](../../../installation/installation-from-sources/#boringssl).
 
 However, none of these options are ideal because they can lock you to specific versions of software and disable the ability to update components and dependencies.

--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -119,7 +119,9 @@ $ node -e "console.log(process.versions['openssl'])"
 
 If the semantic versions are the same, you are good to go! If they differ, however, there are a few ways to resolve the situation, but there is no easy answer:
 
-1. Choose the Nodejs version with the Openssl that matches with your systems' one or that has no Openssl built in (there may be versions of Nodejs that use shared Openssl). For example, Ubuntu Jammy has Openssl 3.0.2, so the only versions of Nodejs suitable for it are v18.0 and v18.1.
+1. Choose the Nodejs version with the Openssl that matches with your systems' one or that has no Openssl built in (there may be versions of Nodejs that use shared Openssl).
+
+   For example, Ubuntu Jammy Jellyfish (22.04) has Openssl 3.0.2, so the only Nodejs versions suitable for it are v18.0 and v18.1. On the other hand, Ubuntu Focal Fossa (20.04) has Openssl 1.1.1, which is compatible with Node LTS v14 and v12. However, be aware that Openssl 1.1.1 [will be unsupported after September 2023](https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/).
 
 2. Try another distribution with Openssl that matches Nodejs.
 


### PR DESCRIPTION
Since we are going to start to support Openssl 3, we have to provide instructions on how to deal with Nodejs that has Openssl statically compiled.

I'm not sure whether we should add "Matching OpenSSL versions" section at the top or bottom. This is a big issue, so maybe users should see it right away when they load the page.

Also, I provided a couple of ways for fixing the issue. However, not all of them are tested in our CI, they were tested only manually a couple of times. So the question arises - should we provide them at all?