### PR TITLE
Update PyThemis installation instructions

### DIFF
--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -78,6 +78,58 @@ you can manually build and install the latest version of Themis from source code
  1. [Build and install Themis Core library](/themis/installation/installation-from-sources/)
     into your system.
 
+ 2. Create a "wheel" package
+
+    <!-- FIXME: For some reason (missing install tools in venv?) the build fails when venv is activated,
+                resolve this or if that's not an issue, just remove this comment -->
+    Run this command outside of virtual environment:
+    ```bash
+    make pythemis_make_wheel
+    ```
+
+    Result package filename will be printed at the end, like this:
+    ```
+    Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
+    ```
+
+ 3. Install PyThemis in your virtual environment
+
+    Activate your virtual environment and run
+    ```bash
+    pip install src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
+    ```
+
+If the virtual environment already contained PyThemis,
+add `--force-reinstall` option to `pip install` to rewrite the previous version
+
+<!-- DRAFT FOR OS PACKAGES FOR PROPER GLOBAL INSTALLATION
+To install PyThemis globally, you need to create a system package first:
+```bash
+make pythemis_make_os_pkg
+```
+
+The result will be located at `src/wrappers/themis/python`.
+
+For Debian/Ubuntu it's a `.deb` file, install with `sudo dpkg -i <filename>`.
+
+*TODO: Add more package types*
+
+-->
+
+## Building latest version from source (deprecated)
+
+{{< hint warning >}}
+[PEP 668](https://peps.python.org/pep-0668/) changed the way Python packages are managed.
+It is now recommended to use `pip install` to only install packages into isolated virtual environments
+while installing things system-wide should be done using OS package manager (like `apt` or `rpm`).
+This means running `sudo make pythemis_install` is no longer recommended as it copies files
+into system-managed Python directory that is no longer maintained by `pip`.
+Consider building a `.whl` and installing it into your venv instead.
+{{< /hint >}}
+
+ 1. [Build and install Themis Core library](/themis/installation/installation-from-sources/)
+    into your system.
+
  2. Install PyThemis package from the source code:
 
     ```bash

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -139,7 +139,7 @@ Alternatively, you could install PyThemis system-wide.
 [PEP 668](https://peps.python.org/pep-0668/) changed the way Python packages are managed.
 It is now recommended to use `pip install` to only install packages into isolated virtual environments
 while installing things system-wide should be done using OS package manager (like `apt` or `rpm`).
-This means running `sudo make pythemis_old_install` is no longer recommended as it copies files
+This means running `sudo make pythemis_install` is no longer recommended as it copies files
 into system-managed Python directory (like `/usr/lib/python3.X/site-packages`) that is no longer maintained by `pip`.
 Consider building a `.whl` and installing it into your venv instead.
 {{< /hint >}}
@@ -150,7 +150,7 @@ Consider building a `.whl` and installing it into your venv instead.
  2. Install PyThemis package from the source code:
 
     ```bash
-    sudo make pythemis_old_install
+    sudo make pythemis_install
     ```
 
     The package will be installed globally into the system.
@@ -161,7 +161,7 @@ Consider building a `.whl` and installing it into your venv instead.
     make prepare_tests_all test_python
     ```
 
-To remove PyThemis after using `pythemis_old_install`, run
+To remove PyThemis after using `pythemis_install`, run
 ```bash
 sudo pip uninstall --break-system-packages pythemis
 ```

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -75,14 +75,16 @@ Once PyThemis is installed, you can [try out code examples](../examples/).
 If the stable package version does not suit your needs,
 you can manually build and install the latest version of Themis from source code.
 
+### Python wheel
+
+A package suitable for installation in Python virtual environments
+
  1. [Build and install Themis Core library](/themis/installation/installation-from-sources/)
     into your system.
 
  2. Install Python dependencies
 
-    Depending on how you want to install PyThemis, there are different requirements.
-
-    To create a `.whl` package for installation inside virtualenv, you'll need `setuptools` and `wheel`
+    You'll need `setuptools` and `wheel`
 
     * Install globally
 
@@ -105,97 +107,95 @@ you can manually build and install the latest version of Themis from source code
       pip install setuptools wheel
       ```
 
-    ---
-
-    To create a system package (i.e. `.deb` one for Debian) you will need `pip` and `fpm`
-
-    * Install globally
-
-      For Debian, Ubuntu:
-
-      ```bash
-      sudo apt install lsb-release python3-pip ruby
-      sudo gem install fpm
-      ```
-
-      For CentOS, RHEL:
-
-      ```bash
-      sudo yum install redhat-lsb-core python3-pip ruby rpm-build
-      sudo gem install fpm
-      ```
-
-    On RHEL you also need to have working `pip` command. If it's not, and you only got `pip3`,
-    create a symlink like this: `sudo ln -s $(which pip3) /usr/bin/pip`.
--->
-
  3. Create a PyThemis package
 
-    * Create a "wheel" for virtualenv
+    {{< hint info >}}
+   If you installed dependencies globally, virtualenv should not be activated during wheel
+   generation since needed packages won't be visible in an isolated environment.
+    {{< /hint >}}
 
-      {{< hint info >}}
-      If you installed dependencies globally, virtualenv should not be activated during wheel
-      generation since needed packages won't be visible in an isolated environment.
-      {{< /hint >}}
+    ```bash
+    make pythemis_make_wheel
+    ```
 
-      ```bash
-      make pythemis_make_wheel
-      ```
-
-      Result package filename will be printed at the end, like this:
-      ```
-      Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
-      ```
-
-    * Create package for your distro
-
-      For Debian, Ubuntu:
-
-      ```bash
-      make deb_python
-      ```
-
-      For CentOS, RHEL:
-
-      ```bash
-      make rpm_python
-      ```
-
-      The result will be located at `build/deb/python3-pythemis_...all.deb`
-      or `build/rpm/python3-pythemis_...all.rpm` respectively.
+    Result package filename will be printed at the end, like this:
+    ```
+    Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
+    ```
 
  4. Install PyThemis
 
-    * Install a wheel into virtualenv
+    ```bash
+    # activate virtualenv if not done yet
+    make pythemis_install_wheel
+    ```
 
-      ```bash
-      # activate virtualenv if not done yet
-      make pythemis_install_wheel
-      ```
+    Or manually run `pip install path/to/pythemis-...-none-any.whl` (the package file previously created).
+    If the virtual environment already contained PyThemis of the same version,
+    add `--force-reinstall` option to rewrite the previous package.
 
-      Or manually run `pip install path/to/pythemis-...-none-any.whl` (the package file previously created).
-      If the virtual environment already contained PyThemis of the same version,
-      add `--force-reinstall` option to rewrite the previous package.
+### OS package
 
-    * Install system package
+A package for system-wide installation, for Debian-like and RHEL-like distros
 
-      For Debian, Ubuntu:
+ 1. [Build and install Themis Core library](/themis/installation/installation-from-sources/)
+    into your system.
 
-      ```bash
-      sudo make pythemis_install_deb
-      ```
+ 2. Install Python dependencies
 
-      For manual installation, there are two ways:
-      1. `sudo apt install ./path/to/package.deb` (the `./` is important here!)
-      2. `sudo dpkg -i path/to/package.deb` (need `apt install python3-six` beforehands)
+    For Debian, Ubuntu:
 
-      For CentOS, RHEL:
+    ```bash
+    sudo apt install lsb-release python3-pip ruby
+    sudo gem install fpm
+    ```
 
-      ```bash
-      sudo make pythemis_install_rpm
-      ```
+    For CentOS, RHEL:
 
-      Or manually run `sudo yum install ./path/to/package.rpm`
+    ```bash
+    sudo yum install redhat-lsb-core python3-pip ruby rpm-build
+    sudo gem install fpm
+    ```
+
+    On RHEL you also need to have working `pip` command. If it's not, and you only got `pip3`,
+    create a symlink like this: `sudo ln -s $(which pip3) /usr/bin/pip`.
+
+ 3. Create a PyThemis package
+
+    For Debian, Ubuntu:
+
+    ```bash
+    make deb_python
+    ```
+
+    For CentOS, RHEL:
+
+    ```bash
+    make rpm_python
+    ```
+
+    The result will be located at `build/deb/python3-pythemis_...all.deb`
+    or `build/rpm/python3-pythemis_...all.rpm` respectively.
+
+ 4. Install PyThemis
+
+    For Debian, Ubuntu:
+
+    ```bash
+    sudo make pythemis_install_deb
+    ```
+
+    For manual installation, there are two ways:
+    1. `sudo apt install ./path/to/package.deb` (the `./` is important here)
+    2. `sudo dpkg -i path/to/package.deb` (need to install `python3-six` and `libthemis` beforehands)
+
+    For CentOS, RHEL:
+
+    ```bash
+    sudo make pythemis_install_rpm
+    ```
+
+    Or manually run `sudo yum install ./path/to/package.rpm`
 
 ## Building latest version from source (deprecated)
 

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -197,7 +197,11 @@ A package for system-wide installation, for Debian-like and RHEL-like distros
 
     Or manually run `sudo yum install ./path/to/package.rpm`
 
-## Building latest version from source (deprecated)
+## Building Themis < 0.15 version from sources (deprecated)
+
+{{< hint warning >}}
+The instructions below are relevant only for Themis older than 0.15. Most likely, you don't need to follow them, and should install the latest Themis instead.
+{{< /hint >}}
 
 {{< hint warning >}}
 [PEP 668](https://peps.python.org/pep-0668/) changed the way Python packages are managed.

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -120,8 +120,8 @@ For Debian/Ubuntu it's a `.deb` file, install with `sudo dpkg -i <filename>`.
 [PEP 668](https://peps.python.org/pep-0668/) changed the way Python packages are managed.
 It is now recommended to use `pip install` to only install packages into isolated virtual environments
 while installing things system-wide should be done using OS package manager (like `apt` or `rpm`).
-This means running `sudo make pythemis_install` is no longer recommended as it copies files
-into system-managed Python directory that is no longer maintained by `pip`.
+This means running `sudo make pythemis_old_install` is no longer recommended as it copies files
+into system-managed Python directory (like `/usr/lib/python3.X/site-packages`) that is no longer maintained by `pip`.
 Consider building a `.whl` and installing it into your venv instead.
 {{< /hint >}}
 
@@ -131,7 +131,7 @@ Consider building a `.whl` and installing it into your venv instead.
  2. Install PyThemis package from the source code:
 
     ```bash
-    make pythemis_install
+    sudo make pythemis_old_install
     ```
 
     The package will be installed globally into the system.
@@ -141,3 +141,8 @@ Consider building a `.whl` and installing it into your venv instead.
     ```bash
     make prepare_tests_all test_python
     ```
+
+To remove PyThemis after using `pythemis_old_install`, run
+```bash
+sudo pip uninstall --break-system-packages pythemis
+```

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -92,11 +92,13 @@ you can manually build and install the latest version of Themis from source code
       sudo apt install python3-setuptools python3-wheel
       ```
 
+<!--
       For CentOS, RHEL:
 
       ```bash
       sudo yum install python3-setuptools python3-wheel
       ```
+-->
 
     * Or install into virtualenv
 
@@ -118,6 +120,7 @@ you can manually build and install the latest version of Themis from source code
       sudo gem install fpm
       ```
 
+<!--
       For CentOS, RHEL:
 
       ```bash
@@ -127,6 +130,7 @@ you can manually build and install the latest version of Themis from source code
 
     On RHEL you also need to have working `pip` command. If it's not, and you only got `pip3`,
     create a symlink like this: `sudo ln -s $(which pip3) /usr/bin/pip`.
+-->
 
  3. Create a PyThemis package
 
@@ -154,14 +158,16 @@ you can manually build and install the latest version of Themis from source code
       make pythemis_deb
       ```
 
+<!--
       For CentOS, RHEL:
 
       ```bash
       make pythemis_rpm
       ```
 
-      The result will be located at `build/deb/python3-pythemis_..._all.deb`
+      The result will be located at `build/rpm/python3-pythemis_..._all.rpm`
       or `build/rpm/python3-pythemis_..._all.rpm` respectively.
+-->
 
  4. Install PyThemis
 
@@ -178,20 +184,23 @@ you can manually build and install the latest version of Themis from source code
 
     * Install system package
 
+      For Debian, Ubuntu:
+
       ```bash
       make pythemis_install_deb
       ```
+
       For manual installation, there are two ways:
       1. `sudo apt install ./path/to/package.deb` (the `./` is important here!)
       2. `sudo dpkg -i path/to/package.deb`
 
+<!--
       For CentOS, RHEL:
 
       ```bash
       make pythemis_install_rpm
       ```
-
-<!-- TODO: Add description about .rpm packages -->
+-->
 
 ## Building latest version from source (deprecated)
 

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -80,56 +80,116 @@ you can manually build and install the latest version of Themis from source code
 
  2. Install Python dependencies
 
-    For Debian, Ubuntu:
+    Depending on how you want to install PyThemis, there are different requirements.
 
-    ```bash
-    sudo apt install python3-setuptools python3-wheel python3-pip python3-venv
-    ```
+    To create a `.whl` package for installation inside virtualenv, you'll need `setuptools` and `wheel`
 
-    For CentOS, RHEL:
+    * Install globally
 
-    ```bash
-    sudo yum install python3-setuptools python3-wheel python3-pip python3-venv
-    ```
+      For Debian, Ubuntu:
 
- 3. Create a "wheel" package
+      ```bash
+      sudo apt install python3-setuptools python3-wheel
+      ```
 
-    ```bash
-    make pythemis_make_wheel
-    ```
+      For CentOS, RHEL:
 
-    Result package filename will be printed at the end, like this:
-    ```
-    Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
-    ```
+      ```bash
+      sudo yum install python3-setuptools python3-wheel
+      ```
 
- 4. Install PyThemis into virtual environment
+    * Or install into virtualenv
 
-    Activate your virtual environment and run
-    ```bash
-    make pythemis_install_wheel
-    ```
+      ```bash
+      # activate virtualenv if not done yet
+      pip install setuptools wheel
+      ```
 
-    Or manually run `pip install path/to/pythemis-...-none-any.whl` (the package file previously created).
-    If the virtual environment already contained PyThemis of the same version,
-    add `--force-reinstall` option to rewrite the previous package.
+    ---
 
-Alternatively, you could install PyThemis system-wide.
+    To create a system package (i.e. `.deb` one for Debian) you will need `pip` and `fpm`
 
-* For Debian, Ubuntu:
+    * Install globally
 
-  ```bash
-  make pythemis_install_deb
-  ```
+      For Debian, Ubuntu:
 
-  This will create a `.deb` package and install it with `sudo apt install`.
+      ```bash
+      sudo apt install python3-pip lsb-release ruby
+      sudo gem install fpm
+      ```
 
-  Or run `make pythemis_deb` to just generate the package.
-  The result will be located at `build/deb/python3-pythemis_..._all.deb`.
-  There are two ways of installing it:
-  1. `sudo apt install ./path/to/package.deb` (the `./` is important here!)
-  2. `sudo dpkg -i path/to/package.deb`
-  The first one is preferred as it will install dependencies along with PyThemis itself, while `dpkg` might just complain and exit.
+      For CentOS, RHEL:
+
+      ```bash
+      sudo yum install python3-pip ruby
+      sudo gem install fpm
+      ```
+
+    On RHEL you also need to have working `pip` command. If it's not, and you only got `pip3`,
+    create a symlink like this: `sudo ln -s $(which pip3) /usr/bin/pip`.
+
+ 3. Create a PyThemis package
+
+    * Create a "wheel" for virtualenv
+
+      {{< hint info >}}
+      If you installed dependencies globally, virtualenv should not be activated during wheel
+      generation since needed packages won't be visible in an isolated environment.
+      {{< /hint >}}
+
+      ```bash
+      make pythemis_make_wheel
+      ```
+
+      Result package filename will be printed at the end, like this:
+      ```
+      Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
+      ```
+
+    * Create package for your distro
+
+      For Debian, Ubuntu:
+
+      ```bash
+      make pythemis_deb
+      ```
+
+      For CentOS, RHEL:
+
+      ```bash
+      make pythemis_rpm
+      ```
+
+      The result will be located at `build/deb/python3-pythemis_..._all.deb`
+      or `build/rpm/python3-pythemis_..._all.rpm` respectively.
+
+ 4. Install PyThemis
+
+    * Install a wheel into virtualenv
+
+      ```bash
+      # activate virtualenv if not done yet
+      make pythemis_install_wheel
+      ```
+
+      Or manually run `pip install path/to/pythemis-...-none-any.whl` (the package file previously created).
+      If the virtual environment already contained PyThemis of the same version,
+      add `--force-reinstall` option to rewrite the previous package.
+
+    * Install system package
+
+      ```bash
+      make pythemis_install_deb
+      ```
+      For manual installation, there are two ways:
+      1. `sudo apt install ./path/to/package.deb` (the `./` is important here!)
+      2. `sudo dpkg -i path/to/package.deb`
+
+      For CentOS, RHEL:
+
+      ```bash
+      make pythemis_install_rpm
+      ```
 
 <!-- TODO: Add description about .rpm packages -->
 

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -92,18 +92,16 @@ you can manually build and install the latest version of Themis from source code
       sudo apt install python3-setuptools python3-wheel
       ```
 
-<!--
       For CentOS, RHEL:
 
       ```bash
       sudo yum install python3-setuptools python3-wheel
       ```
--->
 
     * Or install into virtualenv
 
       ```bash
-      # activate virtualenv if not done yet
+      # create and activate virtualenv if not done yet
       pip install setuptools wheel
       ```
 
@@ -116,15 +114,14 @@ you can manually build and install the latest version of Themis from source code
       For Debian, Ubuntu:
 
       ```bash
-      sudo apt install python3-pip lsb-release ruby
+      sudo apt install lsb-release python3-pip ruby
       sudo gem install fpm
       ```
 
-<!--
       For CentOS, RHEL:
 
       ```bash
-      sudo yum install python3-pip ruby
+      sudo yum install redhat-lsb-core python3-pip ruby rpm-build
       sudo gem install fpm
       ```
 
@@ -155,19 +152,17 @@ you can manually build and install the latest version of Themis from source code
       For Debian, Ubuntu:
 
       ```bash
-      make pythemis_deb
+      make deb_python
       ```
 
-<!--
       For CentOS, RHEL:
 
       ```bash
-      make pythemis_rpm
+      make rpm_python
       ```
 
-      The result will be located at `build/rpm/python3-pythemis_..._all.rpm`
-      or `build/rpm/python3-pythemis_..._all.rpm` respectively.
--->
+      The result will be located at `build/deb/python3-pythemis_...all.deb`
+      or `build/rpm/python3-pythemis_...all.rpm` respectively.
 
  4. Install PyThemis
 
@@ -187,20 +182,20 @@ you can manually build and install the latest version of Themis from source code
       For Debian, Ubuntu:
 
       ```bash
-      make pythemis_install_deb
+      sudo make pythemis_install_deb
       ```
 
       For manual installation, there are two ways:
       1. `sudo apt install ./path/to/package.deb` (the `./` is important here!)
-      2. `sudo dpkg -i path/to/package.deb`
+      2. `sudo dpkg -i path/to/package.deb` (need `apt install python3-six` beforehands)
 
-<!--
       For CentOS, RHEL:
 
       ```bash
-      make pythemis_install_rpm
+      sudo make pythemis_install_rpm
       ```
--->
+
+      Or manually run `sudo yum install ./path/to/package.rpm`
 
 ## Building latest version from source (deprecated)
 

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -73,7 +73,7 @@ Once PyThemis is installed, you can [try out code examples](../examples/).
 ## Building latest version from source
 
 If the stable package version does not suit your needs,
-you can manually build and install the latest version of Themis from source code.
+you can manually build python wheel or `.deb`/`.rpm` package and install the latest version of Themis from source code.
 
 ### Python wheel
 

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -80,9 +80,6 @@ you can manually build and install the latest version of Themis from source code
 
  2. Create a "wheel" package
 
-    <!-- FIXME: For some reason (missing install tools in venv?) the build fails when venv is activated,
-                resolve this or if that's not an issue, just remove this comment -->
-    Run this command outside of virtual environment:
     ```bash
     make pythemis_make_wheel
     ```
@@ -92,15 +89,16 @@ you can manually build and install the latest version of Themis from source code
     Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
     ```
 
- 3. Install PyThemis in your virtual environment
+ 3. Install PyThemis into virtual environment
 
     Activate your virtual environment and run
     ```bash
-    pip install src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
+    make pythemis_install_wheel
     ```
 
-If the virtual environment already contained PyThemis,
-add `--force-reinstall` option to `pip install` to rewrite the previous version
+    Or run `pip install pythemis-...-none-any.whl` (the package file previously created).
+    If the virtual environment already contained PyThemis of the same version,
+    add `--force-reinstall` option to rewrite the previous package.
 
 <!-- DRAFT FOR OS PACKAGES FOR PROPER GLOBAL INSTALLATION
 To install PyThemis globally, you need to create a system package first:

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -78,7 +78,21 @@ you can manually build and install the latest version of Themis from source code
  1. [Build and install Themis Core library](/themis/installation/installation-from-sources/)
     into your system.
 
- 2. Create a "wheel" package
+ 2. Install Python dependencies
+
+    For Debian, Ubuntu:
+
+    ```bash
+    sudo apt install python3-setuptools python3-wheel python3-pip python3-venv
+    ```
+
+    For CentOS, RHEL:
+
+    ```bash
+    sudo yum install python3-setuptools python3-wheel python3-pip python3-venv
+    ```
+
+ 3. Create a "wheel" package
 
     ```bash
     make pythemis_make_wheel
@@ -89,30 +103,29 @@ you can manually build and install the latest version of Themis from source code
     Result: src/wrappers/themis/python/dist/pythemis-0.14.0-py2.py3-none-any.whl
     ```
 
- 3. Install PyThemis into virtual environment
+ 4. Install PyThemis into virtual environment
 
     Activate your virtual environment and run
     ```bash
     make pythemis_install_wheel
     ```
 
-    Or run `pip install pythemis-...-none-any.whl` (the package file previously created).
+    Or manually run `pip install path/to/pythemis-...-none-any.whl` (the package file previously created).
     If the virtual environment already contained PyThemis of the same version,
     add `--force-reinstall` option to rewrite the previous package.
 
-<!-- DRAFT FOR OS PACKAGES FOR PROPER GLOBAL INSTALLATION
 To install PyThemis globally, you need to create a system package first:
-```bash
-make pythemis_make_os_pkg
-```
 
-The result will be located at `src/wrappers/themis/python`.
+* For Debian, Ubuntu:
 
-For Debian/Ubuntu it's a `.deb` file, install with `sudo dpkg -i <filename>`.
+  ```bash
+  make pythemis_deb
+  ```
 
-*TODO: Add more package types*
+  The result will be located at `build/deb/python3-pythemis_..._all.deb`.
+  Install with `sudo dpkg -i <filename>`. Remove with `sudo apt remove python3-pythemis`.
 
--->
+<!-- TODO: Add description about .rpm packages -->
 
 ## Building latest version from source (deprecated)
 

--- a/content/themis/languages/python/installation.md
+++ b/content/themis/languages/python/installation.md
@@ -114,16 +114,22 @@ you can manually build and install the latest version of Themis from source code
     If the virtual environment already contained PyThemis of the same version,
     add `--force-reinstall` option to rewrite the previous package.
 
-To install PyThemis globally, you need to create a system package first:
+Alternatively, you could install PyThemis system-wide.
 
 * For Debian, Ubuntu:
 
   ```bash
-  make pythemis_deb
+  make pythemis_install_deb
   ```
 
+  This will create a `.deb` package and install it with `sudo apt install`.
+
+  Or run `make pythemis_deb` to just generate the package.
   The result will be located at `build/deb/python3-pythemis_..._all.deb`.
-  Install with `sudo dpkg -i <filename>`. Remove with `sudo apt remove python3-pythemis`.
+  There are two ways of installing it:
+  1. `sudo apt install ./path/to/package.deb` (the `./` is important here!)
+  2. `sudo dpkg -i path/to/package.deb`
+  The first one is preferred as it will install dependencies along with PyThemis itself, while `dpkg` might just complain and exit.
 
 <!-- TODO: Add description about .rpm packages -->
 

--- a/content/themis/languages/wasm/installation.md
+++ b/content/themis/languages/wasm/installation.md
@@ -168,6 +168,9 @@ to learn more about managing toolchain versions.
     emmake make wasmthemis
     ```
 
+    Be aware that build may fail if non-WASM Themis was previously build in this same directory.
+    In that case, run `make clean` before building WasmThemis.
+
 The resulting package will be placed into `build/wasm-themis.tgz`
 in Themis source tree.
 


### PR DESCRIPTION
Mention that old `pythemis_install` is deprecated, don't remove that part yet.

Add new section for more modern installation way
* Describe how to build/install a `.whl` package (virtualenv)
* Describe how to build/install a `.deb` package (Debian-like distros)
* Describe how to build/install an `.rpm` package (CentOS, RHEL, probably other Fedora-like)

Wheel building checked on `debian:bookworm` and `registry.access.redhat.com/ubi8/ubi:8.1` (kinda like CentOS/RHEL 8).
`.deb` building checked on `debian:bookworm`. `.rpm` building checked on `centos:7`.