### PR TITLE
Add CPPFLAGS, LDFLAGS to installation example for jsthemis on macOS

### DIFF
--- a/content/themis/languages/nodejs/installation.md
+++ b/content/themis/languages/nodejs/installation.md
@@ -66,6 +66,8 @@ The easiest way to install Themis on macOS is to use Homebrew.
  3. Install JsThemis via npm for your project:
 
     ```bash
+    export CPPFLAGS="-I/opt/homebrew/Cellar/libthemis/0.15.1/include"
+    export LDFLAGS="-L/opt/homebrew/Cellar/libthemis/0.15.1/lib"
     npm install jsthemis
     ```
 


### PR DESCRIPTION
I did something simple. I took an empty project and tried to install and use jsthemis. I remembered what the problem was, reread the sources, went through the history of correspondence and here I have prepared a recipe. 
