### PR TITLE
remove passphrase support from token protect/context imprint modes

### DIFF
--- a/content/themis/crypto-theory/cryptosystems/secure-cell.md
+++ b/content/themis/crypto-theory/cryptosystems/secure-cell.md
@@ -125,7 +125,7 @@ To select the best mode for your needs, consult the following table:
 | Features               | Seal | Token Protect | Context Imprint |
 | ---------------------- | -- | -- | -- |
 | Encryption algorithm   | AES-GCM-256 | AES-GCM-256 | AES-CTR-256 |
-| Passphrase support     | ✅ | ✅ | ✅ |
+| Passphrase support     | ✅ | ❌ | ❌ |
 | Preserve text length   | ❌ | ✅ <sup>*</sup> | ✅ |
 | Required context data  | ❌ | ❌ | ✅ |
 | Integrity verification | ✅ | ✅ | ❌ |


### PR DESCRIPTION
Our [user found](https://github.com/cossacklabs/themis/issues/1044) that we don't have passphrase support for secure cell token protect/context imprint mode and he is right. Let's synchronize docs with current implementation